### PR TITLE
fix: Add debug logging to WebSocket client

### DIFF
--- a/src/wrapper/debug.ts
+++ b/src/wrapper/debug.ts
@@ -1,0 +1,16 @@
+import { appendFileSync } from 'node:fs'
+
+export const DEBUG = !!process.env.RCLAUDE_DEBUG
+const DEBUG_LOG = process.env.RCLAUDE_DEBUG_LOG || (DEBUG ? '/tmp/rclaude-debug.log' : '')
+
+export function debug(msg: string) {
+  if (!DEBUG) return
+  const line = `[${new Date().toISOString()}] ${msg}\n`
+  if (DEBUG_LOG) {
+    try {
+      appendFileSync(DEBUG_LOG, line)
+    } catch {}
+  } else {
+    console.error(`[rclaude] ${msg}`)
+  }
+}

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -18,21 +18,7 @@ import { getTerminalSize, type PtyProcess, setupTerminalPassthrough, spawnClaude
 import { cleanupSettings, writeMergedSettings } from './settings-merge'
 import { createTranscriptWatcher, type TranscriptWatcher } from './transcript-watcher'
 import { createWsClient, type WsClient } from './ws-client'
-
-const DEBUG = !!process.env.RCLAUDE_DEBUG
-const DEBUG_LOG = process.env.RCLAUDE_DEBUG_LOG || (DEBUG ? '/tmp/rclaude-debug.log' : '')
-
-function debug(msg: string) {
-  if (!DEBUG) return
-  const line = `[${new Date().toISOString()}] ${msg}\n`
-  if (DEBUG_LOG) {
-    try {
-      appendFileSync(DEBUG_LOG, line)
-    } catch {}
-  } else {
-    console.error(`[rclaude] ${msg}`)
-  }
-}
+import { DEBUG, debug } from './debug'
 
 function wsToHttpUrl(url: string): string {
   return url.replace('ws://', 'http://').replace('wss://', 'https://')

--- a/src/wrapper/ws-client.ts
+++ b/src/wrapper/ws-client.ts
@@ -21,6 +21,9 @@ import type {
 } from '../shared/protocol'
 import { DEFAULT_CONCENTRATOR_URL } from '../shared/protocol'
 import { BUILD_VERSION } from '../shared/version'
+import { debug as _debug } from './debug'
+
+const debug = (msg: string) => _debug(`[ws] ${msg}`)
 
 export interface WsClientOptions {
   concentratorUrl?: string
@@ -96,14 +99,6 @@ export function createWsClient(options: WsClientOptions): WsClient {
   const maxReconnectAttempts = 10
   const messageQueue: WrapperMessage[] = []
   let heartbeatInterval: Timer | null = null
-
-  const debug = (msg: string) => {
-    if (process.env.RCLAUDE_DEBUG) {
-      const line = `[${new Date().toISOString()}] [ws] ${msg}\n`
-      const logFile = process.env.RCLAUDE_DEBUG_LOG || '/tmp/rclaude-debug.log'
-      try { require('fs').appendFileSync(logFile, line) } catch {}
-    }
-  }
 
   function connect() {
     try {


### PR DESCRIPTION
## Summary
- Add structured debug logging to WS client (connect, close, error events)
- Log close code/reason for diagnosing disconnects
- Extract meaningful error details from ErrorEvent instead of logging opaque object

Logging is gated behind `RCLAUDE_DEBUG` env var — zero overhead in normal operation.

## Test plan
- [ ] Set `RCLAUDE_DEBUG=1` and verify logs appear in `/tmp/rclaude-debug.log`
- [ ] Trigger a WS disconnect and verify close code/reason are logged
- [ ] Verify no debug output when `RCLAUDE_DEBUG` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)