### PR TITLE
feat: Show plan content inline at ExitPlanMode in transcript view

### DIFF
--- a/web/src/components/transcript/group-view.tsx
+++ b/web/src/components/transcript/group-view.tsx
@@ -93,11 +93,13 @@ export function GroupView({
   resultMap,
   showThinking = false,
   subagents,
+  planContext,
 }: {
   group: DisplayGroup
   resultMap: Map<string, { result: string; extra?: Record<string, unknown> }>
   showThinking?: boolean
   subagents?: SubagentRef
+  planContext?: { content: string; path?: string }
 }) {
   const expandAll = useSessionsStore(state => state.expandAll)
   const userLabel = useSessionsStore(state => (state.globalSettings.userLabel as string)?.trim() || 'USER')
@@ -320,6 +322,9 @@ export function GroupView({
                   toolUseResult={item.extra}
                   subagents={subagents}
                   renderAgentInline={(agentId, toolId) => <AgentTranscriptInline agentId={agentId} toolId={toolId} />}
+                  {...(item.tool.name === 'ExitPlanMode' && planContext
+                    ? { planContent: planContext.content, planPath: planContext.path }
+                    : {})}
                 />
               )
             default:

--- a/web/src/components/transcript/tool-line.tsx
+++ b/web/src/components/transcript/tool-line.tsx
@@ -24,10 +24,14 @@ export function ToolLine({
   toolUseResult,
   subagents,
   renderAgentInline,
+  planContent,
+  planPath,
 }: {
   tool: TranscriptContentBlock
   result?: string
   toolUseResult?: Record<string, unknown>
+  planContent?: string
+  planPath?: string
   subagents?: Array<{
     agentId: string
     agentType: string
@@ -279,7 +283,10 @@ export function ToolLine({
       summary = 'entering plan mode'
       break
     case 'ExitPlanMode':
-      summary = 'exiting plan mode'
+      summary = planPath ? `plan: ${shortPath(planPath)}` : 'exiting plan mode'
+      if (planContent) {
+        details = <WritePreview content={planContent} filePath={planPath || 'plan.md'} />
+      }
       break
     case 'NotebookEdit': {
       const cellId = input.cell_id as string

--- a/web/src/components/transcript/transcript-view.tsx
+++ b/web/src/components/transcript/transcript-view.tsx
@@ -41,6 +41,29 @@ export function TranscriptView({
     return { mainGroups: main, queuedGroups: queued }
   }, [groups])
 
+  // Extract plan content from entries for ExitPlanMode display.
+  // Finds the last Write to a plans/*.md path across all entries.
+  const planContext = useMemo(() => {
+    let content: string | undefined
+    let path: string | undefined
+    for (const entry of entries) {
+      const msg = (entry as any)?.message
+      if (msg?.role !== 'assistant') continue
+      const blocks = msg.content
+      if (!Array.isArray(blocks)) continue
+      for (const block of blocks) {
+        if (block.type === 'tool_use' && block.name === 'Write' && block.input) {
+          const filePath = block.input.file_path as string
+          if (filePath && /plans\/[^/]+\.md$/.test(filePath)) {
+            content = block.input.content as string
+            path = filePath
+          }
+        }
+      }
+    }
+    return content ? { content, path } : undefined
+  }, [entries])
+
   // Lift subagents selector here (once) instead of per-GroupView (N times)
   // Return a primitive string so Zustand's Object.is check works - avoids re-renders
   // from session_update creating new array references with identical content
@@ -200,6 +223,7 @@ export function TranscriptView({
                   resultMap={resultMap}
                   showThinking={showThinking}
                   subagents={subagents}
+                  planContext={planContext}
                 />
               )
             })()}


### PR DESCRIPTION
When Claude exits plan mode, the transcript now displays the full plan file content inline using WritePreview (syntax highlighted, with line numbers). Scans all transcript entries for the last Write to a plans/*.md path and renders it at the ExitPlanMode tool entry.

Previously only the one-line "exiting plan mode" summary was shown, and the plan content was scattered across Write/Edit tool entries in earlier groups.