### PR TITLE
fix: decouple MCP server from --dangerously-load-development-channels (fixes ExitPlanMode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ OPTIONS:
   --no-terminal          Disable remote terminal capability
   --no-channels          Disable MCP channel (channels are ON by default)
   --channels             Enable MCP channel (already default, for explicitness)
+  --mcp-tools-only       Run MCP server without channel input (fixes plan mode)
   --rclaude-help         Show rclaude help
 
 All other arguments pass through to claude CLI.
@@ -572,10 +573,11 @@ All other arguments pass through to claude CLI.
 **MCP Channel mode** (enabled by default) connects Claude Code to rclaude via MCP,
 enabling dashboard input without PTY keystroke injection and inter-session messaging.
 
-> **Note:** Claude Code 2.1.83+ disables `AskUserQuestion` and plan mode tools when
-> channels are active. These features require interactive terminal prompts that can't
-> flow through the channel yet. Use `--no-channels` or `RCLAUDE_CHANNELS=0` if you
-> need plan mode or structured questions. Terminal TTY access still works regardless.
+> **Note:** When channel input is active (`--dangerously-load-development-channels` is passed),
+> `ExitPlanMode` may appear in the deferred tools list but ToolSearch cannot resolve its schema.
+> Use `--mcp-tools-only` (or `RCLAUDE_CHANNEL_INPUT=0`) to keep MCP tools while disabling channel
+> input — this restores native plan mode behavior. As a fallback, Claude can call
+> `mcp__rclaude__toggle_plan_mode` to inject a `/plan` toggle via the terminal session.
 
 **Environment variables:**
 
@@ -583,7 +585,8 @@ enabling dashboard input without PTY keystroke injection and inter-session messa
 |----------|-------------|
 | `RCLAUDE_SECRET` | Shared secret (alternative to `--rclaude-secret`) |
 | `RCLAUDE_CONCENTRATOR` | Concentrator URL (alternative to `--concentrator`) |
-| `RCLAUDE_CHANNELS` | Set to `0` to disable MCP channel (enabled by default) |
+| `RCLAUDE_CHANNELS` | Set to `0` to disable MCP channel entirely (enabled by default) |
+| `RCLAUDE_CHANNEL_INPUT` | Set to `0` to disable channel input while keeping MCP tools (`--mcp-tools-only`) |
 | `RCLAUDE_DEBUG` | Set to `1` to enable debug logging |
 | `RCLAUDE_DEBUG_LOG` | Debug log file path (default: `/tmp/rclaude-debug.log`) |
 

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -137,6 +137,7 @@ OPTIONS:
   --no-terminal          Disable remote terminal capability
   --no-channels          Disable MCP channel (channels are ON by default)
   --channels             Enable MCP channel (already default, for explicitness)
+  --mcp-tools-only       Run MCP server without channel input (fixes plan mode)
   --rclaude-help         Show this help message
 
 ENVIRONMENT:
@@ -194,7 +195,8 @@ async function main() {
   let concentratorSecret = process.env.RCLAUDE_SECRET
   let noConcentrator = false
   let noTerminal = false
-  let channelEnabled = process.env.RCLAUDE_CHANNELS !== '0'
+  let mcpEnabled = process.env.RCLAUDE_CHANNELS !== '0'
+  let channelInputEnabled = mcpEnabled && process.env.RCLAUDE_CHANNEL_INPUT !== '0'
   const claudeArgs: string[] = []
 
   debug(`Concentrator URL: ${concentratorUrl} (source: ${process.env.RCLAUDE_CONCENTRATOR ? 'env' : 'default'})`)
@@ -215,9 +217,14 @@ async function main() {
     } else if (arg === '--no-terminal') {
       noTerminal = true
     } else if (arg === '--channels') {
-      channelEnabled = true
+      mcpEnabled = true
+      channelInputEnabled = true
     } else if (arg === '--no-channels') {
-      channelEnabled = false
+      mcpEnabled = false
+      channelInputEnabled = false
+    } else if (arg === '--mcp-tools-only') {
+      mcpEnabled = true
+      channelInputEnabled = false
     } else {
       claudeArgs.push(arg)
     }
@@ -373,7 +380,7 @@ async function main() {
     // Build capabilities list
     const capabilities = [
       ...(!noTerminal ? ['terminal' as const] : []),
-      ...(channelEnabled ? ['channel' as const] : []),
+      ...(channelInputEnabled ? ['channel' as const] : []),
     ]
 
     wsClient = createWsClient({
@@ -412,7 +419,7 @@ async function main() {
         const isSlashCommand = input.trimStart().startsWith('/')
 
         // Channel mode: push through MCP instead of PTY injection
-        if (channelEnabled && isMcpChannelReady() && !isSlashCommand) {
+        if (channelInputEnabled && isMcpChannelReady() && !isSlashCommand) {
           pushChannelMessage(input).then(sent => {
             if (sent) {
               diag('channel', `Input via MCP (${input.length} chars)`)
@@ -577,7 +584,7 @@ async function main() {
         pendingSendResult?.(result as { ok: boolean; error?: string; conversationId?: string })
       },
       onChannelDeliver(delivery) {
-        if (channelEnabled && isMcpChannelReady()) {
+        if (channelInputEnabled && isMcpChannelReady()) {
           const meta: Record<string, string> = {
             sender: 'session',
             from_session: delivery.fromSession,
@@ -594,7 +601,7 @@ async function main() {
         // Link requests are handled by the dashboard UI, not by Claude
       },
       onPermissionResponse(requestId: string, behavior: 'allow' | 'deny') {
-        if (channelEnabled && isMcpChannelReady()) {
+        if (channelInputEnabled && isMcpChannelReady()) {
           sendPermissionResponse(requestId, behavior)
           diag('channel', `Permission response: ${requestId} -> ${behavior}`)
         }
@@ -891,8 +898,8 @@ async function main() {
   let devChannelConfirmed = false
 
   // Initialize MCP channel if enabled
-  if (channelEnabled) {
-    diag('channel', 'Channel mode enabled')
+  if (mcpEnabled) {
+    diag('channel', `MCP mode enabled (channel input: ${channelInputEnabled})`)
     initMcpChannel({
       onNotify(message, title) {
         diag('channel', `Notify: ${title ? `[${title}] ` : ''}${message.slice(0, 80)}`)
@@ -983,6 +990,10 @@ async function main() {
       onDisconnect() {
         diag('channel', 'Channel disconnected')
       },
+      onTogglePlanMode() {
+        diag('channel', 'toggle_plan_mode: injecting /plan via PTY')
+        if (ptyProcess) ptyProcess.write('/plan\r')
+      },
     })
   }
 
@@ -993,7 +1004,7 @@ async function main() {
   // Start local HTTP server for hook callbacks (+ MCP endpoint when channels enabled)
   const { server: localServer, port: localServerPort } = await startLocalServer({
     sessionId: internalId,
-    channelEnabled,
+    mcpEnabled,
     onHookEvent(event: HookEvent) {
       // Extract Claude's real session ID from SessionStart
       if (event.hookEvent === 'SessionStart' && event.data) {
@@ -1184,7 +1195,7 @@ async function main() {
       '- `title` (optional): Notification title (defaults to project name)',
       '',
       "This sends a real push notification to the user's phone/browser AND shows a toast in the dashboard.",
-      ...(channelEnabled
+      ...(channelInputEnabled
         ? [
             '',
             '# MCP Channel (rclaude)',
@@ -1214,8 +1225,31 @@ async function main() {
             '',
             'Session linking is managed by the user via the dashboard -- you cannot approve or block sessions.',
             'Always include conversation_id when replying to maintain context threading.',
+            '',
+            '# Plan Mode (rclaude)',
+            '',
+            'When using MCP channels, ExitPlanMode may be listed as a deferred tool but',
+            'cannot be invoked (a known Claude Code interaction with development channels).',
+            'If you are in plan mode and ExitPlanMode is uncallable for any reason,',
+            'call `mcp__rclaude__toggle_plan_mode` directly as a fallback — do NOT use',
+            'ToolSearch for this, MCP tools are always directly callable by their full name.',
+            'Do NOT try Skill() workarounds or Bash commands -- they will not work.',
           ]
-        : []),
+        : mcpEnabled
+          ? [
+              '',
+              '# MCP Tools (rclaude)',
+              '',
+              '**Available MCP tools (rclaude server):**',
+              "- `mcp__rclaude__notify` - Send a push notification to the user's devices (phone, browser)",
+              '- `mcp__rclaude__share_file` - Upload a local file and get a public URL for the dashboard user',
+              '- `mcp__rclaude__list_sessions` - Discover other active Claude Code sessions',
+              '- `mcp__rclaude__send_message` - Send a message to another session',
+              '',
+              'Prefer the MCP `notify` tool over the curl endpoint.',
+              'Use `share_file` to share screenshots, images, build artifacts, or any file the user needs to see.',
+            ]
+          : []),
     ].join('\n'),
   )
   claudeArgs.push('--append-system-prompt-file', promptFile)
@@ -1224,10 +1258,10 @@ async function main() {
   // Convert WS URL to HTTP for tools/scripts that need to call the concentrator REST API
   const concentratorHttpUrl = noConcentrator ? undefined : wsToHttpUrl(concentratorUrl)
 
-  // Add --channels + --mcp-config for MCP channel support
+  // Add --mcp-config (always when MCP enabled) and optionally --dangerously-load-development-channels
   // Write MCP config to a temp file (CC 2.1.83+ may resolve file configs before inline JSON)
   let mcpConfigPath: string | undefined
-  if (channelEnabled) {
+  if (mcpEnabled) {
     mcpConfigPath = join(rclaudeDir, `mcp-${internalId}.json`)
     await Bun.write(
       mcpConfigPath,
@@ -1236,7 +1270,7 @@ async function main() {
       }),
     )
   }
-  const finalClaudeArgs = channelEnabled
+  const finalClaudeArgs = channelInputEnabled
     ? [
         '--dangerously-load-development-channels',
         'server:rclaude',
@@ -1244,7 +1278,9 @@ async function main() {
         mcpConfigPath as string,
         ...claudeArgs,
       ]
-    : claudeArgs
+    : mcpEnabled
+      ? ['--mcp-config', mcpConfigPath!, ...claudeArgs]
+      : claudeArgs
 
   ptyProcess = spawnClaude({
     args: finalClaudeArgs,
@@ -1258,7 +1294,7 @@ async function main() {
       // CC uses Ink/React TUI -- the warning text is painted via cursor positioning,
       // not as sequential text. But "Entertoconfirm" appears in the raw stream
       // (ANSI-stripped, no spaces due to Ink rendering). Detect that + confirm.
-      if (channelEnabled && !devChannelConfirmed) {
+      if (channelInputEnabled && !devChannelConfirmed) {
         const plain = data.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b[=>?][0-9]*[a-zA-Z]/g, '')
         if (plain.includes('Entertoconfirm')) {
           devChannelConfirmed = true
@@ -1304,7 +1340,7 @@ async function main() {
     stopLocalServer(localServer)
     wsClient?.close()
     cleanupSettings(internalId, rclaudeDir).catch(() => {})
-    if (channelEnabled) {
+    if (mcpEnabled) {
       closeMcpChannel().catch(() => {})
       if (mcpConfigPath)
         try {

--- a/src/wrapper/local-server.ts
+++ b/src/wrapper/local-server.ts
@@ -68,7 +68,7 @@ const ASK_TIMEOUT_MS = 90_000 // 90s -- must be under curl's 120s --max-time
 
 export interface LocalServerOptions {
   sessionId: string
-  channelEnabled: boolean
+  mcpEnabled: boolean
   onHookEvent: (event: HookEvent) => void
   onNotify?: (message: string, title?: string) => void
   onAskQuestion?: (request: AskQuestionRequest) => void
@@ -101,7 +101,7 @@ async function findAvailablePort(startPort: number): Promise<number> {
  * Create and start the local HTTP server for hook callbacks
  */
 export async function startLocalServer(options: LocalServerOptions): Promise<{ server: HttpServer; port: number }> {
-  const { sessionId, channelEnabled, onHookEvent, onNotify, onAskQuestion, hasDashboardSubscribers } = options
+  const { sessionId, mcpEnabled, onHookEvent, onNotify, onAskQuestion, hasDashboardSubscribers } = options
 
   const port = await findAvailablePort(19000 + Math.floor(Math.random() * 1000))
 
@@ -238,7 +238,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<{ s
       }
 
       // MCP Streamable HTTP endpoint for channel communication
-      if (channelEnabled && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      if (mcpEnabled && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
         return handleMcpRequest(req)
       }
 

--- a/src/wrapper/mcp-channel.ts
+++ b/src/wrapper/mcp-channel.ts
@@ -47,6 +47,7 @@ export interface McpChannelCallbacks {
   ) => Promise<{ ok: boolean; error?: string; conversationId?: string }>
   onPermissionRequest?: (data: PermissionRequestData) => void
   onDisconnect?: () => void
+  onTogglePlanMode?: () => void
 }
 
 interface McpChannelState {
@@ -143,6 +144,15 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
           required: ['to', 'intent', 'message'],
         },
       },
+      {
+        name: 'toggle_plan_mode',
+        description:
+          'Toggle plan mode off via the terminal session. Use this as a fallback ONLY when ExitPlanMode is not available as a deferred tool but plan mode is still active. The toggle takes effect after your current response completes.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {},
+        },
+      },
     ],
   }))
 
@@ -185,6 +195,11 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
         debug(`[channel] send_message to ${to}: ${message.slice(0, 60)}`)
         const response = result.conversationId ? `Sent. conversation_id: ${result.conversationId}` : 'Sent.'
         return { content: [{ type: 'text', text: response }] }
+      }
+      case 'toggle_plan_mode': {
+        callbacks.onTogglePlanMode?.()
+        debug('[channel] toggle_plan_mode: sent /plan via PTY')
+        return { content: [{ type: 'text', text: 'Plan mode toggle sent via PTY. Plan mode will turn off after your current response.' }] }
       }
       default:
         return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }


### PR DESCRIPTION
## Problem

When channel input is active, `ExitPlanMode` appears in the deferred tools list but ToolSearch cannot resolve its schema, making it uncallable. This is a known Claude Code bug ([anthropics/claude-code#39342](https://github.com/anthropics/claude-code/issues/39342)) triggered by the `--dangerously-load-development-channels` flag.

The symptom: Claude enters plan mode, tries to exit via `ExitPlanMode`, ToolSearch fails to return its schema, Claude loops trying `Skill(exit-plan)` (doesn't exist), and eventually asks the user to type `/plan` manually.

The root cause in rclaude: `channelEnabled` was controlling two independent things as a single unit:
1. Starting the MCP HTTP server + passing `--mcp-config` (so `notify`, `share_file`, `send_message` work)
2. Passing `--dangerously-load-development-channels server:rclaude` (routes dashboard input via MCP instead of PTY)

The fix is to keep the MCP server running while optionally not passing the channel flag.

## Changes

Splits `channelEnabled` into two variables:

- **`mcpEnabled`** — starts the MCP server, writes `--mcp-config`. Tools (`notify`, `share_file`, `send_message`, `list_sessions`) remain available.
- **`channelInputEnabled`** — additionally passes `--dangerously-load-development-channels`. Dashboard messages route via MCP instead of PTY keystroke injection.

### New flag: `--mcp-tools-only`

```
rclaude --mcp-tools-only
```

Or via env: `RCLAUDE_CHANNEL_INPUT=0`

MCP tools stay available. Channel input falls back to PTY. `ExitPlanMode` works again.

### Behavior table

| | `--channels` (default) | `--mcp-tools-only` | `--no-channels` |
|---|---|---|---|
| MCP server runs | ✅ | ✅ | ❌ |
| `notify`, `share_file`, `send_message` | ✅ | ✅ | ❌ |
| Dashboard input via MCP channel | ✅ | ❌ → PTY fallback | ❌ → PTY |
| `--dangerously-load-development-channels` passed | ✅ | ❌ | ❌ |
| `ExitPlanMode` works | ❌ (CC bug #39342) | ✅ | ✅ |

**Default unchanged** — `--channels` behavior is still the default. `--mcp-tools-only` is an explicit opt-out for users who need plan mode.

### Bonus: `mcp__rclaude__toggle_plan_mode`

Added as a PTY-injection fallback for sessions using channel input. Claude can call this directly (no ToolSearch needed) to inject `/plan\r` into the terminal. The prompt instructions are updated accordingly.

## Test plan

- [ ] `rclaude --mcp-tools-only` → plan mode works (`ExitPlanMode` resolves), `mcp__rclaude__notify` still callable
- [ ] `rclaude` (default) → channel input works as before
- [ ] `rclaude --no-channels` → no MCP, PTY only (unchanged)
- [ ] `RCLAUDE_CHANNEL_INPUT=0` env var → same as `--mcp-tools-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)