### PR TITLE
fix: replace --append-system-prompt-file with --append-system-prompt

### DIFF
--- a/COLLABORATION.md
+++ b/COLLABORATION.md
@@ -185,7 +185,7 @@ curl -s localhost:$RCLAUDE_PORT/collab/send \
 ## System Prompt Extension
 
 When a session has active links, rclaude appends to the system prompt
-file (`--append-system-prompt-file`):
+via `--append-system-prompt`:
 
 ```
 # Session Collaboration

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -1218,7 +1218,7 @@ async function main() {
         : []),
     ].join('\n'),
   )
-  claudeArgs.push('--append-system-prompt-file', promptFile)
+  claudeArgs.push('--append-system-prompt', readFileSync(promptFile, 'utf-8'))
 
   // Spawn claude with PTY
   // Convert WS URL to HTTP for tools/scripts that need to call the concentrator REST API


### PR DESCRIPTION
## Summary
- `--append-system-prompt-file` was removed in Claude Code 2.1.86
- Read prompt file content and pass it inline via `--append-system-prompt` instead
- Updated COLLABORATION.md docs to match

## Test plan
- [ ] Launch an rclaude session and verify system prompt content is passed correctly
- [ ] Confirm prompt file is still written to disk for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)