### PR TITLE
fix: passthrough CLI subcommands directly to claude binary

### DIFF
--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -186,9 +186,39 @@ function extToMediaType(ext: string): string {
   return map[ext] || 'application/octet-stream'
 }
 
+// Claude CLI subcommands that should be passed through directly (no wrapper logic)
+const CLAUDE_PASSTHROUGH_SUBCOMMANDS = new Set([
+  'agents',
+  'auth',
+  'auto-mode',
+  'doctor',
+  'install',
+  'mcp',
+  'plugin',
+  'plugins',
+  'setup-token',
+  'update',
+  'upgrade',
+])
+
 async function main() {
   // Parse our specific args, pass the rest to claude
   const args = process.argv.slice(2)
+
+  // Detect Claude CLI subcommands and pass them through directly — these are
+  // management commands that don't need the rclaude wrapper (concentrator, MCP,
+  // system prompt, PTY, etc.). Passing them through the wrapper causes spurious
+  // errors like "unknown option '--append-system-prompt-file'".
+  const firstNonFlag = args.find(a => !a.startsWith('-'))
+  if (firstNonFlag && CLAUDE_PASSTHROUGH_SUBCOMMANDS.has(firstNonFlag)) {
+    debug(`Passthrough subcommand detected: ${firstNonFlag} — exec'ing claude directly`)
+    const proc = Bun.spawnSync(['claude', ...args], {
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    process.exit(proc.exitCode ?? 1)
+  }
 
   let concentratorUrl = process.env.RCLAUDE_CONCENTRATOR || DEFAULT_CONCENTRATOR_URL
   let concentratorSecret = process.env.RCLAUDE_SECRET


### PR DESCRIPTION
## Summary
- `rclaude` wraps every invocation through its full startup flow (concentrator, MCP, system prompt injection, PTY) — even for utility subcommands like `mcp add`, `auth`, `doctor`
- This causes `error: unknown option '--append-system-prompt-file'` when running e.g. `claude mcp add ...` through the rclaude alias
- Fix: detect CLI subcommands early and exec them directly through the real `claude` binary, bypassing the wrapper

## Root cause
The arg parser loop at L203 pushes all non-rclaude args into `claudeArgs`, then the wrapper unconditionally appends flags like `--append-system-prompt-file` before spawning. Subcommands like `mcp add` don't accept those flags.

## Test plan
- [ ] `claude mcp add --transport http <url>` works through rclaude alias
- [ ] `claude auth` works through rclaude alias
- [ ] `claude doctor` works through rclaude alias
- [ ] Normal interactive `claude` sessions still go through the full wrapper flow
- [ ] `claude --version` still works (not a subcommand, passes through wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)