### PR TITLE
feat: Add toggle_plan_mode MCP tool for plan mode fallback

### DIFF
--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -1056,6 +1056,10 @@ async function main() {
       onDisconnect() {
         diag('channel', 'Channel disconnected')
       },
+      onTogglePlanMode() {
+        diag('channel', 'toggle_plan_mode: injecting /plan via PTY')
+        if (ptyProcess) ptyProcess.write('/plan\r')
+      },
     })
   }
 

--- a/src/wrapper/mcp-channel.ts
+++ b/src/wrapper/mcp-channel.ts
@@ -47,6 +47,7 @@ export interface McpChannelCallbacks {
   ) => Promise<{ ok: boolean; error?: string; conversationId?: string }>
   onPermissionRequest?: (data: PermissionRequestData) => void
   onDisconnect?: () => void
+  onTogglePlanMode?: () => void
 }
 
 interface McpChannelState {
@@ -143,6 +144,12 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
           required: ['to', 'intent', 'message'],
         },
       },
+      {
+        name: 'toggle_plan_mode',
+        description:
+          'Toggle plan mode via the terminal session. Use as a fallback when ExitPlanMode is not available. The toggle takes effect after your current response completes.',
+        inputSchema: { type: 'object' as const, properties: {} },
+      },
     ],
   }))
 
@@ -186,6 +193,10 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
           debug(`[channel] send_message to ${to}: ${message.slice(0, 60)}`)
           const response = result.conversationId ? `Sent. conversation_id: ${result.conversationId}` : 'Sent.'
           return { content: [{ type: 'text', text: response }] }
+        }
+        case 'toggle_plan_mode': {
+          callbacks.onTogglePlanMode?.()
+          return { content: [{ type: 'text', text: 'Plan mode toggle sent via PTY.' }] }
         }
         default:
           return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }


### PR DESCRIPTION
## Summary

Extracted from PR #30. Adds a single focused change: the `toggle_plan_mode` MCP tool that injects `/plan` via PTY when `ExitPlanMode` is unavailable due to channel restrictions (CC 2.1.83+).

## Changes

- `McpChannelCallbacks` interface: added `onTogglePlanMode?: () => void`
- `ListToolsRequestSchema` handler: registered `toggle_plan_mode` tool with description
- `CallToolRequestSchema` handler: added `toggle_plan_mode` case that calls the callback
- `src/wrapper/index.ts`: implemented `onTogglePlanMode` callback - writes `/plan\r` to the PTY

## Test plan

- [ ] Start rclaude with channels enabled (`--channels` or default)
- [ ] When in plan mode, call `toggle_plan_mode` MCP tool from Claude
- [ ] Verify `/plan` is injected into the PTY and plan mode exits