### PR TITLE
fix: update-check stderr corrupting Claude Code TUI + SW banner RELOAD bug

### DIFF
--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -361,16 +361,6 @@ async function main() {
   }
   debug(`Concentrator: ${noConcentrator ? 'DISABLED' : 'ENABLED'} (url: ${concentratorUrl})`)
 
-  // Non-blocking update check at startup — fire and forget
-  checkForUpdate()
-    .then(result => {
-      if (!result.upToDate && !result.error) {
-        const behind = result.behindBy ? `${result.behindBy} commit(s)` : 'commits'
-        console.error(`\x1b[33m⚠ rclaude update available (${behind} behind) — git pull && bun run build:client\x1b[0m`)
-      }
-    })
-    .catch(() => {}) // silently ignore network errors on startup
-
   // Session ID: reuse from revive flow so concentrator resumes the existing session
   // Wrapper ID: always unique per process (for socket routing, terminal attachment)
   const sessionId = process.env.RCLAUDE_SESSION_ID || process.env.RCLAUDE_WRAPPER_ID || randomUUID()

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -12,6 +12,11 @@ const FILE_CACHE = 'rclaude-files-v1'
 const FILE_CACHE_MAX = 50
 const FILE_CACHE_MAX_SIZE = 2 * 1024 * 1024
 
+// Tracks the build hash from the install event so activate knows which precache
+// is the new one. Module-level state persists across the install→activate cycle
+// of a single SW instance.
+let installedBuildHash = null
+
 // ─── Install: precache from manifest ─────────────────────────────
 
 self.addEventListener('install', event => {
@@ -19,6 +24,7 @@ self.addEventListener('install', event => {
     fetch('/asset-manifest.json')
       .then(res => res.json())
       .then(async manifest => {
+        installedBuildHash = manifest.buildHash
         const cache = await caches.open(`${PRECACHE}-${manifest.buildHash}`)
         const urls = manifest.files.map(f => f.url).filter(u => !u.endsWith('.map'))
         // Also cache the root HTML
@@ -31,32 +37,34 @@ self.addEventListener('install', event => {
   self.skipWaiting()
 })
 
-// ─── Activate: clean old precaches, claim clients ────────────────
+// ─── Activate: clean old precaches, claim clients, signal real updates ──
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches
-      .keys()
-      .then(keys => {
-        // Find the current precache name
-        const current = keys.find(k => k.startsWith(PRECACHE))
-        return Promise.all(
-          keys
-            .filter(k => k.startsWith(PRECACHE) && k !== current)
-            .map(k => {
-              console.log(`[sw] deleting old cache: ${k}`)
-              return caches.delete(k)
-            }),
-        )
-      })
-      .then(() => clients.claim()),
+    (async () => {
+      const keys = await caches.keys()
+      const allPrecaches = keys.filter(k => k.startsWith(PRECACHE))
+      const currentName = installedBuildHash ? `${PRECACHE}-${installedBuildHash}` : null
+      // Old precaches = anything that isn't the freshly installed one.
+      // If install failed (currentName === null), keep everything to avoid wiping the working cache.
+      const oldPrecaches = currentName ? allPrecaches.filter(k => k !== currentName) : []
+      for (const k of oldPrecaches) {
+        console.log(`[sw] deleting old cache: ${k}`)
+        await caches.delete(k)
+      }
+      await clients.claim()
+      // Only notify clients of an "update" if there was a previous precache to replace.
+      // Fresh installs (e.g. after clearCacheAndReload) must not fire sw-updated, otherwise
+      // the banner reappears immediately and RELOAD looks broken.
+      if (oldPrecaches.length > 0) {
+        const fromHash = oldPrecaches[0].slice(PRECACHE.length + 1) || null
+        const cls = await clients.matchAll({ type: 'window' })
+        for (const client of cls) {
+          client.postMessage({ type: 'sw-updated', from: fromHash, to: installedBuildHash })
+        }
+      }
+    })(),
   )
-  // Notify all clients that a new SW is active
-  clients.matchAll({ type: 'window' }).then(cls => {
-    for (const client of cls) {
-      client.postMessage({ type: 'sw-updated' })
-    }
-  })
 })
 
 // ─── Fetch: precache-first, with runtime caching for /file/* ─────

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -35,7 +35,8 @@ import {
 import { useWebSocket } from '@/hooks/use-websocket'
 import { executeCommand, useCommand } from '@/lib/commands'
 import { canTerminal } from '@/lib/types'
-import { clearCacheAndReload, isMobileViewport, isTouchDevice } from '@/lib/utils'
+import { clearCacheAndReload, isMobileViewport, isTouchDevice, PRE_RELOAD_KEY } from '@/lib/utils'
+import { BUILD_VERSION } from '../../src/shared/version'
 
 // Swipe-right from left edge to open session list (mobile)
 function useSwipeToOpen(onOpen: () => void) {
@@ -74,15 +75,54 @@ function Dashboard() {
   const [sheetOpen, setSheetOpen] = useState(() => isMobileViewport() && !useSessionsStore.getState().selectedSessionId)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => localStorage.getItem('sidebar-collapsed') === 'true')
   const [showUserAdmin, setShowUserAdmin] = useState(false)
-  const [swUpdateAvailable, setSwUpdateAvailable] = useState(false)
+  const [swUpdate, setSwUpdate] = useState<{ from: string | null; to: string | null } | null>(null)
 
   // Listen for service worker update notifications
   useEffect(() => {
     function handleSwMessage(event: MessageEvent) {
-      if (event.data?.type === 'sw-updated') setSwUpdateAvailable(true)
+      if (event.data?.type === 'sw-updated') {
+        setSwUpdate({ from: event.data.from ?? null, to: event.data.to ?? null })
+      }
     }
     navigator.serviceWorker?.addEventListener('message', handleSwMessage)
     return () => navigator.serviceWorker?.removeEventListener('message', handleSwMessage)
+  }, [])
+
+  // Post-reload feedback: detect whether clearCacheAndReload actually moved us
+  // to a new build, and surface a toast either way. Also auto-dismisses any
+  // banner that fired before the build hash was actually updated.
+  useEffect(() => {
+    let stashed: string | null
+    try {
+      stashed = localStorage.getItem(PRE_RELOAD_KEY)
+    } catch {
+      return
+    }
+    if (!stashed) return
+    try {
+      localStorage.removeItem(PRE_RELOAD_KEY)
+    } catch {}
+    try {
+      const { hash, ts } = JSON.parse(stashed) as { hash: string; ts: number }
+      // Stale stashes (>5 min) are ignored — user probably navigated, not reloaded.
+      if (!hash || typeof ts !== 'number' || Date.now() - ts > 5 * 60 * 1000) return
+      const current = BUILD_VERSION.gitHashShort
+      if (current && current !== hash) {
+        window.dispatchEvent(
+          new CustomEvent('rclaude-toast', {
+            detail: { title: 'UPDATED', body: `Web build ${hash} → ${current}` },
+          }),
+        )
+      } else {
+        window.dispatchEvent(
+          new CustomEvent('rclaude-toast', {
+            detail: { title: 'NO UPDATE', body: `Already on latest build (${hash})` },
+          }),
+        )
+        // Suppress any false-positive banner from the fresh SW install.
+        setSwUpdate(null)
+      }
+    } catch {}
   }, [])
   const selectedSessionId = useSessionsStore(s => s.selectedSessionId)
   const setEvents = useSessionsStore(s => s.setEvents)
@@ -464,11 +504,15 @@ function Dashboard() {
 
   return (
     <div className="h-full flex flex-col p-2 sm:p-4 max-w-[1400px] mx-auto overflow-hidden" {...swipeHandlers}>
-      {/* SW update banner */}
-      {swUpdateAvailable && (
+      {/* SW update banner — frontend bundle only, not wrapper/backend */}
+      {swUpdate && (
         <div className="mb-2 px-3 py-2 bg-cyan-500/10 border border-cyan-500/30 rounded font-mono text-xs text-cyan-400 flex items-center gap-2 shrink-0">
-          <span className="font-bold">UPDATE</span>
-          <span className="flex-1">New version available</span>
+          <span className="font-bold" title="New web app build available">
+            WEB UPDATE
+          </span>
+          <span className="flex-1 truncate">
+            {swUpdate.from && swUpdate.to ? `${swUpdate.from} → ${swUpdate.to}` : 'New web build available'}
+          </span>
           <button
             type="button"
             onClick={() => clearCacheAndReload()}
@@ -478,7 +522,7 @@ function Dashboard() {
           </button>
           <button
             type="button"
-            onClick={() => setSwUpdateAvailable(false)}
+            onClick={() => setSwUpdate(null)}
             className="px-2 py-0.5 text-[10px] font-bold text-muted-foreground hover:text-foreground transition-colors"
           >
             LATER

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,5 +1,9 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { BUILD_VERSION } from '../../../src/shared/version'
+
+/** Key used to detect post-reload outcome and surface a feedback toast. */
+export const PRE_RELOAD_KEY = 'rclaude-pre-reload'
 
 /** Tailwind `sm` breakpoint - below this is mobile */
 export const MOBILE_BREAKPOINT = 640
@@ -120,8 +124,16 @@ export function haptic(pattern: 'tap' | 'double' | 'success' | 'error' | 'tick' 
   }
 }
 
-/** Clear all SW caches, unregister service worker, and reload */
+/** Clear all SW caches, unregister service worker, and reload.
+ * Stashes the current build hash so the next page load can show feedback
+ * (success: hash changed; no-op: hash identical). */
 export async function clearCacheAndReload(): Promise<void> {
+  try {
+    localStorage.setItem(
+      PRE_RELOAD_KEY,
+      JSON.stringify({ hash: BUILD_VERSION.gitHashShort, ts: Date.now() }),
+    )
+  } catch {}
   const keys = await caches.keys()
   await Promise.all(keys.map(k => caches.delete(k)))
   const reg = await navigator.serviceWorker?.getRegistration('/sw.js')


### PR DESCRIPTION
## Summary

Two related fixes around the rclaude/dashboard update flow.

### 1. Wrapper update-check stderr corrupted Claude Code's TUI

The fire-and-forget `checkForUpdate()` introduced for the startup update check wrote a yellow `⚠ rclaude update available` line to stderr whenever the GitHub round-trip happened to finish — anywhere from ~100ms to ~10s after `rclaude` started. By the time the network call resolved, Claude Code had usually already drawn its banner and prompt box, so the warning landed in the middle of the TUI:

\`\`\`
[settings] Written /Users/.../rclaude/settings/settings-...json (port=19738 session=...)
⚠ rclaude update available (6 commit(s) behind) — git pull && bun run build:client
▗ ▗   ▖ ▖  Claude Code v2.1.100
           Opus 4.6 (1M context) · Claude Max
  ▘▘ ▝▝    ~/code/launchpad

──────────────────────────────────────────────
❯
\`\`\`

Sometimes it landed over the prompt box itself. Context: PR #36 (closed) was the startup-update-check feature that introduced this; the merged PR #35 added the underlying \`checkForUpdate()\` machinery that we still want to keep.

**Fix:** delete the fire-and-forget block. The check itself stays — \`checkForUpdate()\` and friends are still imported and used by the \`--rclaude-check-update\` flag and the \`check_update\` MCP tool. Future work (separate RFC) should surface staleness through the concentrator/dashboard rather than wrapper stderr.

### 2. Dashboard SW \"WEB UPDATE\" banner: RELOAD silently failed + ambiguous label + no feedback

Three compounding problems with the dashboard's SW update banner:

**a. RELOAD button looked broken.** Clicking RELOAD on the \"New version available\" banner appeared to do nothing — the banner reappeared instantly after the page reloaded.

Root cause: \`web/public/sw.js\`'s \`activate\` handler posted \`{type: 'sw-updated'}\` to all clients on **every** activate, including fresh installs. \`clearCacheAndReload()\` (\`web/src/lib/utils.ts\`) unregisters the SW before reloading. After reload, \`main.tsx\` re-registers \`/sw.js\` as a fresh install (no prior controller). The new SW activated, posted \`sw-updated\`, and the banner reappeared immediately. RELOAD effectively did nothing visible.

Secondary issue: the \`clients.matchAll(...)\` postMessage was outside \`event.waitUntil(...)\`, so it raced \`clients.claim()\`.

**Fix:** track \`installedBuildHash\` from the install event in module-level SW state. In activate, only fire \`sw-updated\` when there was a *previous* precache to replace (i.e. genuine update, not fresh install). Also moved the postMessage inside \`event.waitUntil\` so it sequences after \`clients.claim()\` instead of racing it. The message now also includes \`from\` and \`to\` build hashes.

**b. No success/failure feedback.** Three indistinguishable post-RELOAD outcomes today:

| Outcome | Visible signal before this fix |
|---|---|
| Successfully updated to a new build | Banner gone (looks identical to \"click did nothing\") |
| Already on latest, server has no new build | Banner reappears (looks like RELOAD broke) |
| Network error during reload | Banner reappears (looks like RELOAD broke) |

**Fix:** \`clearCacheAndReload()\` now stashes the current \`BUILD_VERSION.gitHashShort\` plus a timestamp in \`localStorage\` before reload. On next page load, the dashboard compares the stashed hash against the current build hash:

- **Different** → success toast: \`UPDATED — Web build <old> → <new>\`
- **Same** → info toast: \`NO UPDATE — Already on latest build (<hash>)\` *and* the false-positive banner is suppressed for the rest of the session
- Stashes older than 5 minutes are ignored (user navigated, didn't reload)

Toasts use the existing \`rclaude-toast\` custom event infrastructure (\`web/src/components/toast.tsx\`).

**c. Ambiguous label.** \"New version available\" didn't say *what* updated. Users reasonably read it as \"upstream rclaude has new commits\" or \"backend is out of date,\" when in fact it's strictly a frontend bundle refresh.

**Fix:** rename to \`WEB UPDATE\`, add a tooltip, and show the build-hash transition inline (\`<from> → <to>\`) when available. Doubles as client-awareness — users can see exactly which build they're on and which they're moving to.

## Out of scope (for follow-up)

These came up during the design discussion but were deliberately kept out of this PR to keep the diff focused on verified bugs:

- **PWA awareness improvements**: \`visibilitychange\` → \`reg.update()\` on foreground; \`controllerchange\` listener as backup signal; display-mode + SW state in nerd modal SW tab; manual \"Check for update\" button; App Badging API; last-update-check timestamp.
- **Unified staleness model (RFC)**: wrapper and agent reporting their \`BUILD_VERSION\` to the concentrator on connect, concentrator centralizing the GitHub poll (one fetch per hour, broadcast to all sessions), STALE pills in the session list with context-appropriate reload actions per parent process (tmux respawn vs launchd vs bare shell). This is a bigger architectural change touching session lifecycle, tmux/launchd/macOS specifics, and trust boundaries — needs its own design discussion.

## Testing

Verified locally on a Mac Mini hosting concentrator under Launchpad, dashboard accessed both as a regular browser tab and as an installed PWA:

- [x] Wrapper TUI no longer corrupted: yellow stderr line never appears, Claude Code banner renders cleanly even when behind upstream
- [x] Fresh SW install (manual unregister + reload) no longer fires false-positive \`WEB UPDATE\` banner
- [x] Real concentrator rebuild (Launchpad refresh with new \`web/dist\` → new manifest hash) → banner appears with \`<from> → <to>\` transition → RELOAD click → success toast \`UPDATED — Web build <old> → <new>\`, banner gone
- [x] Manual \"Clear Cache & Reload\" from nerd modal SW tab when no real update is available → \`NO UPDATE — Already on latest build\` toast, no lingering banner
- [x] \`bun run typecheck\` clean (root + web)
- [x] \`bun run build:web\` and \`bun run build:wrapper\` clean

## Files changed

- \`src/wrapper/index.ts\` — 10-line deletion
- \`web/public/sw.js\` — track install hash, only fire sw-updated on real updates, sequence inside waitUntil, include from/to in message
- \`web/src/lib/utils.ts\` — \`clearCacheAndReload\` stashes pre-reload hash; export \`PRE_RELOAD_KEY\`
- \`web/src/app.tsx\` — banner state shape now \`{from, to}\`; post-reload effect dispatches success/no-op toast and suppresses false positives; banner label tightened to \`WEB UPDATE\` with hash transition