### PR TITLE
fix: change startup settings log from stderr to stdout

### DIFF
--- a/src/wrapper/settings-merge.ts
+++ b/src/wrapper/settings-merge.ts
@@ -294,7 +294,7 @@ export async function writeMergedSettings(
   const settingsPath = dir ? `${dir}/settings/settings-${sessionId}.json` : `/tmp/rclaude-settings-${sessionId}.json`
 
   await Bun.write(settingsPath, JSON.stringify(settings, null, 2))
-  console.error(
+  console.log(
     `[settings] Written ${settingsPath} (port=${port} session=${sessionId.slice(0, 8)} hooks=${Object.keys(settings.hooks || {}).length})`,
   )
 


### PR DESCRIPTION
## Summary
- Changes `console.error` to `console.log` in `settings-merge.ts` for the settings-written message
- The informational message was rendering in red (stderr) making it look like an error on startup

Fixes #37

## Test plan
- [ ] Start rclaude and verify the settings log line no longer appears in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)