### PR TITLE
fix: resolve tmux not found when agent runs as daemon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,16 @@ echo -e "${BOLD}  └───────────────────�
 echo ""
 
 # ─── Prerequisites ───────────────────────────────────────────────
+if ! command -v tmux &>/dev/null; then
+  warn "tmux is not installed. The agent uses tmux to spawn and revive sessions from the dashboard."
+  case "$(uname -s)" in
+    Darwin) echo -e "  Install with: ${CYAN}brew install tmux${NC}" ;;
+    Linux)  echo -e "  Install with: ${CYAN}sudo apt install tmux${NC} or ${CYAN}sudo dnf install tmux${NC}" ;;
+  esac
+else
+  ok "Found tmux $(tmux -V)"
+fi
+
 if ! command -v bun &>/dev/null; then
   warn "bun is not installed. Installing..."
   curl -fsSL https://bun.sh/install | bash

--- a/scripts/revive-session.sh
+++ b/scripts/revive-session.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Ensure package-manager-installed binaries (tmux, etc.) are on PATH even when
+# running as a launchd/systemd service, which inherits a minimal PATH.
+for dir in /opt/homebrew/bin /usr/local/bin /home/linuxbrew/.linuxbrew/bin "$HOME/.linuxbrew/bin"; do
+  [[ -d "$dir" ]] && [[ ":$PATH:" != *":$dir:"* ]] && export PATH="$dir:$PATH"
+done
+
 CWD="$2"
 SPAWN_MODE=""
 RESUME_ID=""

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -65,6 +65,32 @@ function getMachineId(): string {
 
 const RECONNECT_DELAY_MS = 5000
 
+// ─── tmux binary discovery ────────────────────────────────────────────
+// When the agent runs as a launchd daemon (macOS), it inherits a minimal PATH
+// (e.g. /usr/bin:/bin:/usr/sbin:/sbin) without Homebrew's /opt/homebrew/bin.
+// Resolve tmux to an absolute path at startup by checking common package manager
+// locations directly, without mutating process.env.PATH (which would widen the
+// PATH inherited by all child processes).
+function findTmuxBinary(): string {
+  // First, check the existing PATH
+  const fromPath = Bun.which('tmux')
+  if (fromPath) return fromPath
+  // Check common package manager locations that may not be in PATH
+  const extraDirs = [
+    '/opt/homebrew/bin', // Homebrew on Apple Silicon
+    '/usr/local/bin', // Homebrew on Intel Mac / common Linux
+    '/home/linuxbrew/.linuxbrew/bin', // Homebrew on Linux (system-wide)
+    join(process.env.HOME || '/root', '.linuxbrew', 'bin'), // Homebrew on Linux (per-user)
+  ]
+  for (const dir of extraDirs) {
+    const candidate = join(dir, 'tmux')
+    if (existsSync(candidate)) return candidate
+  }
+  return 'tmux' // bare fallback — will fail with a clear error at the call site
+}
+
+const TMUX_BIN = findTmuxBinary()
+
 // ─── PID Registry (headless child process tracking) ─────────────────
 const PID_REGISTRY_DIR = join(process.env.HOME || '/root', '.rclaude')
 const PID_REGISTRY_PATH = join(PID_REGISTRY_DIR, 'agent-sessions.json')
@@ -799,7 +825,7 @@ async function spawnSession(
   const exitCode = proc.exitCode
 
   // After spawn, check if the tmux session/window actually exists
-  const tmuxCheck = Bun.spawnSync(['tmux', 'list-windows', '-t', 'remote-claude'])
+  const tmuxCheck = Bun.spawnSync([TMUX_BIN, 'list-windows', '-t', 'remote-claude'])
   const tmuxWindows = tmuxCheck.stdout.toString().trim()
 
   diag('spawn', 'Script completed', {
@@ -1134,7 +1160,7 @@ function connect(
               const wid = reviveMsg.wrapperId
               const jid = reviveMsg.jobId
               setTimeout(() => {
-                const check = Bun.spawnSync(['tmux', 'list-panes', '-t', paneId], {
+                const check = Bun.spawnSync([TMUX_BIN, 'list-panes', '-t', paneId], {
                   stdout: 'pipe',
                   stderr: 'pipe',
                 })
@@ -1250,7 +1276,7 @@ function connect(
               const jid = spawnMsg.jobId
               const spawnCwd = expandedCwd
               setTimeout(() => {
-                const check = Bun.spawnSync(['tmux', 'list-panes', '-t', paneId], {
+                const check = Bun.spawnSync([TMUX_BIN, 'list-panes', '-t', paneId], {
                   stdout: 'pipe',
                   stderr: 'pipe',
                 })


### PR DESCRIPTION
## Summary
- Agent fails with `tmux: command not found` when running as a launchd daemon because it inherits a minimal PATH without package manager bin dirs (e.g. `/opt/homebrew/bin`)
- Resolves tmux to an absolute path at startup by checking common Homebrew/Linuxbrew locations, without mutating `process.env.PATH`
- Adds PATH augmentation to `revive-session.sh` as defense in depth
- Adds a tmux prerequisite warning (not blocker) to `install.sh`

## Details

Three call sites in `src/agent/index.ts` used bare `tmux` in `Bun.spawnSync()` arrays. When the agent runs as a launchd daemon on macOS, it inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — Homebrew's `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel) aren't included.

The fix:
1. **`src/agent/index.ts`**: New `findTmuxBinary()` function resolves tmux to an absolute path at startup by first checking `Bun.which()`, then probing common package manager locations directly. Does **not** mutate `process.env.PATH`, so child processes don't inherit a wider PATH than the daemon started with.
2. **`scripts/revive-session.sh`**: Add PATH augmentation at the top of the script (defense in depth — users may customize this script independently). Scoped to the script process; children run `zsh -li` which resets PATH from the shell profile.
3. **`install.sh`**: Warn (not block) if tmux isn't installed — the agent uses tmux for remote session spawn/revive from the dashboard, but headless sessions work without it.

## Test plan
- [ ] Run agent as a launchd service on macOS (Apple Silicon) — verify revive works
- [ ] Run agent from an interactive shell — verify no regression
- [ ] Run `install.sh` without tmux installed — verify warning is shown but install continues
- [ ] Verify headless sessions work without tmux installed
- [ ] Verify `findTmuxBinary()` resolves correctly with minimal PATH (tested locally: `env -i PATH=/usr/bin:/bin HOME=$HOME bun -e ...` confirmed `/opt/homebrew/bin/tmux` resolved without PATH mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)