### PR TITLE
feat(spawn): unify spawn pipeline + MCP diagnostics/progress

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "marked": "^17.0.6",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
-        "vite": "^8.0.6",
+        "vite": "8.0.6",
         "vite-tsconfig-paths": "^6.1.1",
         "web-push": "^3.6.7",
         "zod": "^4.3.6",

--- a/src/concentrator/handlers/agent.ts
+++ b/src/concentrator/handlers/agent.ts
@@ -60,10 +60,22 @@ const spawnResult: MessageHandler = (ctx, data) => {
   const ok = data.success ? 'OK' : 'FAIL'
   ctx.log.debug(`Spawn ${ok}${data.error ? ` (${data.error})` : ''}`)
   ctx.sessions.resolveSpawn(data.requestId as string, data)
-  // Forward failure to job subscribers so launch monitor can show the error
   const jobId = data.jobId as string | undefined
-  if (jobId && !data.success) {
-    ctx.sessions.failJob(jobId, (data.error as string) || 'Spawn failed')
+  if (jobId) {
+    if (data.success) {
+      // Agent confirmed the wrapper process has started (tmux session is up)
+      ctx.sessions.forwardJobEvent(jobId, {
+        type: 'launch_progress',
+        jobId,
+        step: 'wrapper_booted',
+        status: 'done',
+        t: Date.now(),
+        detail: typeof data.tmuxSession === 'string' ? data.tmuxSession : undefined,
+      })
+    } else {
+      // Forward failure to job subscribers so launch monitor can show the error
+      ctx.sessions.failJob(jobId, (data.error as string) || 'Spawn failed')
+    }
   }
 }
 
@@ -104,6 +116,17 @@ const spawnFailed: MessageHandler = (ctx, data) => {
   if (wrapperId) {
     const jobId = ctx.sessions.getJobByWrapper(wrapperId)
     if (jobId) {
+      // Emit first-class progress alongside the legacy job_failed event
+      ctx.sessions.forwardJobEvent(jobId, {
+        type: 'launch_progress',
+        jobId,
+        step: 'failed',
+        status: 'error',
+        t: Date.now(),
+        error: errorMsg,
+        wrapperId,
+        elapsed: elapsedMs,
+      })
       ctx.sessions.failJob(jobId, errorMsg)
     }
   }

--- a/src/concentrator/handlers/index.ts
+++ b/src/concentrator/handlers/index.ts
@@ -12,6 +12,7 @@ import { registerInterSessionHandlers } from './inter-session'
 import { registerPermissionHandlers } from './permissions'
 import { registerPlanApprovalHandlers } from './plan-approval'
 import { registerSessionLifecycleHandlers } from './session-lifecycle'
+import { registerSpawnHandlers } from './spawn'
 import { registerTerminalHandlers } from './terminal'
 import { registerTranscriptHandlers } from './transcript'
 import { registerVoiceHandlers } from './voice'
@@ -26,6 +27,7 @@ export function registerAllHandlers(): void {
   registerPermissionHandlers()
   registerPlanApprovalHandlers()
   registerSessionLifecycleHandlers()
+  registerSpawnHandlers()
   registerTerminalHandlers()
   registerTranscriptHandlers()
   registerVoiceHandlers()

--- a/src/concentrator/handlers/inter-session.ts
+++ b/src/concentrator/handlers/inter-session.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { resolveSpawnConfig } from '../../shared/spawn-defaults'
+import { mapProjectTrust, type SpawnCallerContext } from '../../shared/spawn-permissions'
 import type { SpawnRequest } from '../../shared/spawn-schema'
 import { getGlobalSettings } from '../global-settings'
 import type { MessageHandler } from '../handler-context'
@@ -147,10 +148,23 @@ const handleChannelSpawn: MessageHandler = (ctx, data) => {
     headless: data.headless !== false,
   }
 
+  // Inter-session callers are always another session acting MCP-style --
+  // `requireBenevolent()` above already enforces the trust floor, but
+  // dispatchSpawn re-validates via assertSpawnAllowed for belt-and-braces.
+  const callerCwd = ctx.caller?.cwd ?? null
+  const callerTrust = callerCwd ? mapProjectTrust(getProjectSettings(callerCwd)?.trustLevel) : 'trusted'
+  const callerContext: SpawnCallerContext = {
+    kind: 'mcp',
+    hasSpawnPermission: true,
+    trustLevel: callerTrust,
+    cwd: callerCwd,
+  }
+
   dispatchSpawn(req, {
     sessions: ctx.sessions,
     getProjectSettings,
     getGlobalSettings,
+    callerContext,
     rendezvousCallerSessionId: callerSession,
   })
     .then(result => {

--- a/src/concentrator/handlers/inter-session.ts
+++ b/src/concentrator/handlers/inter-session.ts
@@ -5,9 +5,12 @@
 
 import { randomUUID } from 'node:crypto'
 import { resolveSpawnConfig } from '../../shared/spawn-defaults'
+import type { SpawnRequest } from '../../shared/spawn-schema'
 import { getGlobalSettings } from '../global-settings'
 import type { MessageHandler } from '../handler-context'
 import { registerHandlers } from '../message-router'
+import { getProjectSettings } from '../project-settings'
+import { dispatchSpawn } from '../spawn-dispatch'
 
 /** Resolve effective effort level from project + global settings */
 function resolveEffort(
@@ -125,87 +128,40 @@ const handleChannelSpawn: MessageHandler = (ctx, data) => {
   if (!callerSession) return
 
   ctx.requireBenevolent()
-  const agent = ctx.requireAgent()
+  ctx.requireAgent()
 
   const cwd = data.cwd as string
   if (!cwd || typeof cwd !== 'string') {
     ctx.reply({ type: 'channel_spawn_result', ok: false, error: 'Missing cwd' })
     return
   }
-  if (data.mode === 'resume' && !data.resumeId) {
-    ctx.reply({ type: 'channel_spawn_result', ok: false, error: 'resumeId required for resume mode' })
-    return
+
+  // Build a SpawnRequest from the narrower channel_spawn payload.
+  // Inter-session callers today only pass cwd/mkdir/mode/resumeId/headless.
+  // `effort` is resolved from project/global settings inside dispatchSpawn.
+  const req: SpawnRequest = {
+    cwd,
+    mkdir: !!data.mkdir,
+    mode: (data.mode as SpawnRequest['mode']) || 'fresh',
+    resumeId: typeof data.resumeId === 'string' ? data.resumeId : undefined,
+    headless: data.headless !== false,
   }
 
-  const requestId = randomUUID()
-  const wrapperId = randomUUID()
-
-  const spawnPromise = new Promise<{ success?: boolean; error?: string; tmuxSession?: string }>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      ctx.sessions.removeSpawnListener(requestId)
-      reject(new Error('Spawn timed out (15s)'))
-    }, 15000)
-    ctx.sessions.addSpawnListener(requestId, msg => {
-      clearTimeout(timeout)
-      resolve(msg as { success?: boolean; error?: string; tmuxSession?: string })
-    })
-    agent.send(
-      JSON.stringify({
-        type: 'spawn',
-        requestId,
-        cwd,
-        wrapperId,
-        mkdir: !!data.mkdir,
-        mode: data.mode || 'fresh',
-        resumeId: data.resumeId,
-        headless: data.headless !== false, // default true
-        effort: resolveEffort(cwd, ctx.getProjectSettings),
-      }),
-    )
+  dispatchSpawn(req, {
+    sessions: ctx.sessions,
+    getProjectSettings,
+    getGlobalSettings,
+    rendezvousCallerSessionId: callerSession,
   })
-
-  spawnPromise
     .then(result => {
-      if (!result.success) {
-        ctx.reply({ type: 'channel_spawn_result', ok: false, error: result.error || 'Spawn failed' })
-        return
+      if (result.ok) {
+        ctx.reply({ type: 'channel_spawn_result', ok: true, wrapperId: result.wrapperId })
+        ctx.log.debug(`Benevolent spawn: -> ${cwd}`)
+      } else {
+        ctx.reply({ type: 'channel_spawn_result', ok: false, error: result.error })
       }
-
-      // Register rendezvous
-      ctx.sessions
-        .addRendezvous(wrapperId, callerSession, cwd, 'spawn')
-        .then(session => {
-          const callerWs = ctx.sessions.getSessionSocket(callerSession)
-          if (callerWs) {
-            callerWs.send(
-              JSON.stringify({
-                type: 'spawn_ready',
-                sessionId: session.id,
-                cwd: session.cwd,
-                wrapperId,
-                session,
-              }),
-            )
-          }
-        })
-        .catch(err => {
-          const callerWs = ctx.sessions.getSessionSocket(callerSession)
-          if (callerWs) {
-            callerWs.send(
-              JSON.stringify({
-                type: 'spawn_timeout',
-                wrapperId,
-                cwd,
-                error: typeof err === 'string' ? err : 'Spawn rendezvous timed out',
-              }),
-            )
-          }
-        })
-
-      ctx.reply({ type: 'channel_spawn_result', ok: true, wrapperId })
-      ctx.log.debug(`Benevolent spawn: -> ${cwd}`)
     })
-    .catch(err => {
+    .catch((err: unknown) => {
       ctx.reply({
         type: 'channel_spawn_result',
         ok: false,

--- a/src/concentrator/handlers/inter-session.ts
+++ b/src/concentrator/handlers/inter-session.ts
@@ -140,12 +140,17 @@ const handleChannelSpawn: MessageHandler = (ctx, data) => {
   // Build a SpawnRequest from the narrower channel_spawn payload.
   // Inter-session callers today only pass cwd/mkdir/mode/resumeId/headless.
   // `effort` is resolved from project/global settings inside dispatchSpawn.
+  //
+  // jobId flows through when the caller wants to track the spawn: the MCP
+  // wrapper subscribes before sending channel_spawn so it can receive
+  // launch_progress events and forward them as notifications/progress.
   const req: SpawnRequest = {
     cwd,
     mkdir: !!data.mkdir,
     mode: (data.mode as SpawnRequest['mode']) || 'fresh',
     resumeId: typeof data.resumeId === 'string' ? data.resumeId : undefined,
     headless: data.headless !== false,
+    jobId: typeof data.jobId === 'string' ? data.jobId : undefined,
   }
 
   // Inter-session callers are always another session acting MCP-style --
@@ -169,10 +174,10 @@ const handleChannelSpawn: MessageHandler = (ctx, data) => {
   })
     .then(result => {
       if (result.ok) {
-        ctx.reply({ type: 'channel_spawn_result', ok: true, wrapperId: result.wrapperId })
+        ctx.reply({ type: 'channel_spawn_result', ok: true, wrapperId: result.wrapperId, jobId: req.jobId })
         ctx.log.debug(`Benevolent spawn: -> ${cwd}`)
       } else {
-        ctx.reply({ type: 'channel_spawn_result', ok: false, error: result.error })
+        ctx.reply({ type: 'channel_spawn_result', ok: false, error: result.error, jobId: req.jobId })
       }
     })
     .catch((err: unknown) => {

--- a/src/concentrator/handlers/inter-session.ts
+++ b/src/concentrator/handlers/inter-session.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
+import { resolveSpawnConfig } from '../../shared/spawn-defaults'
 import { getGlobalSettings } from '../global-settings'
 import type { MessageHandler } from '../handler-context'
 import { registerHandlers } from '../message-router'
@@ -13,9 +14,7 @@ function resolveEffort(
   cwd: string,
   getProjectSettings: (cwd: string) => { defaultEffort?: string } | null,
 ): string | undefined {
-  const proj = getProjectSettings(cwd)
-  const raw = proj?.defaultEffort || getGlobalSettings().defaultEffort
-  return raw && raw !== 'default' ? raw : undefined
+  return resolveSpawnConfig({}, getProjectSettings(cwd), getGlobalSettings()).effort
 }
 
 const handleQuitRemoteSession: MessageHandler = (ctx, data) => {

--- a/src/concentrator/handlers/spawn.ts
+++ b/src/concentrator/handlers/spawn.ts
@@ -8,6 +8,7 @@
  * -- caller correlates by jobId.
  */
 
+import { mapProjectTrust, type SpawnCallerContext } from '../../shared/spawn-permissions'
 import { spawnRequestSchema } from '../../shared/spawn-schema'
 import { getGlobalSettings } from '../global-settings'
 import type { MessageHandler } from '../handler-context'
@@ -34,12 +35,22 @@ const handleSpawnRequest: MessageHandler = (ctx, data) => {
   }
   const req = parsed.data
 
+  const callerCwd = ctx.caller?.cwd ?? null
+  const trustLevel = callerCwd ? mapProjectTrust(ctx.getProjectSettings(callerCwd)?.trustLevel) : 'trusted'
+  const callerContext: SpawnCallerContext = {
+    kind: 'ws',
+    hasSpawnPermission: true, // already validated by ctx.requirePermission above
+    trustLevel,
+    cwd: callerCwd,
+  }
+
   // Fire-and-track: dispatchSpawn is async but the router doesn't await handlers.
   // We catch promise rejections to ensure the caller always gets an ack.
   dispatchSpawn(req, {
     sessions: ctx.sessions,
     getProjectSettings,
     getGlobalSettings,
+    callerContext,
     // Dashboard-initiated spawns do not participate in the inter-session
     // rendezvous channel -- the dashboard already gets launch events via jobId.
     rendezvousCallerSessionId: null,

--- a/src/concentrator/handlers/spawn.ts
+++ b/src/concentrator/handlers/spawn.ts
@@ -84,6 +84,49 @@ const handleSpawnRequest: MessageHandler = (ctx, data) => {
     })
 }
 
+/**
+ * Fetch a diagnostic snapshot for a job by ID. Mirrors what the dashboard's
+ * "Copy diagnostics" button builds client-side, but driven from concentrator
+ * state so MCP / other back-end callers can retrieve it after the fact.
+ *
+ * Permission: `spawn` -- same gate as actually spawning. Anyone who could
+ * have initiated the spawn can read its trail.
+ */
+const handleGetSpawnDiagnostics: MessageHandler = (ctx, data) => {
+  ctx.requirePermission('spawn', '*')
+
+  const jobId = typeof data.jobId === 'string' ? data.jobId : null
+  if (!jobId) {
+    ctx.reply({
+      type: 'spawn_diagnostics_result',
+      ok: false,
+      error: 'jobId required',
+    })
+    return
+  }
+
+  const diag = ctx.sessions.getJobDiagnostics(jobId)
+  if (!diag) {
+    ctx.reply({
+      type: 'spawn_diagnostics_result',
+      ok: false,
+      jobId,
+      error: 'Job not found (may have expired after 5 minutes)',
+    })
+    return
+  }
+
+  ctx.reply({
+    type: 'spawn_diagnostics_result',
+    ok: true,
+    jobId,
+    diagnostics: diag,
+  })
+}
+
 export function registerSpawnHandlers(): void {
-  registerHandlers({ spawn_request: handleSpawnRequest })
+  registerHandlers({
+    spawn_request: handleSpawnRequest,
+    get_spawn_diagnostics: handleGetSpawnDiagnostics,
+  })
 }

--- a/src/concentrator/handlers/spawn.ts
+++ b/src/concentrator/handlers/spawn.ts
@@ -1,0 +1,78 @@
+/**
+ * Dashboard spawn handler (WS `spawn_request`).
+ *
+ * Counterpart to the HTTP /api/spawn route -- delegates to the same
+ * `dispatchSpawn` helper so behavior stays in lockstep.
+ *
+ * Ack shape: `{ type: 'spawn_request_ack', ok, jobId?, wrapperId?, tmuxSession?, error? }`
+ * -- caller correlates by jobId.
+ */
+
+import { spawnRequestSchema } from '../../shared/spawn-schema'
+import { getGlobalSettings } from '../global-settings'
+import type { MessageHandler } from '../handler-context'
+import { registerHandlers } from '../message-router'
+import { getProjectSettings } from '../project-settings'
+import { dispatchSpawn } from '../spawn-dispatch'
+
+const handleSpawnRequest: MessageHandler = (ctx, data) => {
+  const jobIdFromClient = typeof data.jobId === 'string' ? data.jobId : undefined
+
+  // Permission first -- dashboard users must hold `spawn` permission.
+  // Wrappers/agents bypass (not applicable here; spawn_request is dashboard-only).
+  ctx.requirePermission('spawn', '*')
+
+  const parsed = spawnRequestSchema.safeParse(data)
+  if (!parsed.success) {
+    ctx.reply({
+      type: 'spawn_request_ack',
+      ok: false,
+      jobId: jobIdFromClient,
+      error: parsed.error.message,
+    })
+    return
+  }
+  const req = parsed.data
+
+  // Fire-and-track: dispatchSpawn is async but the router doesn't await handlers.
+  // We catch promise rejections to ensure the caller always gets an ack.
+  dispatchSpawn(req, {
+    sessions: ctx.sessions,
+    getProjectSettings,
+    getGlobalSettings,
+    // Dashboard-initiated spawns do not participate in the inter-session
+    // rendezvous channel -- the dashboard already gets launch events via jobId.
+    rendezvousCallerSessionId: null,
+  })
+    .then(result => {
+      if (result.ok) {
+        ctx.reply({
+          type: 'spawn_request_ack',
+          ok: true,
+          jobId: req.jobId,
+          wrapperId: result.wrapperId,
+          tmuxSession: result.tmuxSession,
+        })
+      } else {
+        ctx.reply({
+          type: 'spawn_request_ack',
+          ok: false,
+          jobId: req.jobId,
+          error: result.error,
+        })
+      }
+    })
+    .catch((err: unknown) => {
+      ctx.log.error('spawn_request dispatch error', err)
+      ctx.reply({
+        type: 'spawn_request_ack',
+        ok: false,
+        jobId: req.jobId,
+        error: err instanceof Error ? err.message : 'Spawn dispatch failed',
+      })
+    })
+}
+
+export function registerSpawnHandlers(): void {
+  registerHandlers({ spawn_request: handleSpawnRequest })
+}

--- a/src/concentrator/routes.ts
+++ b/src/concentrator/routes.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path'
 import { Hono } from 'hono'
 import type { ListDirsResult, SendInput, Session, SpawnResult, TeamInfo } from '../shared/protocol'
 import { resolveSpawnConfig } from '../shared/spawn-defaults'
+import { mapProjectTrust, type SpawnCallerContext } from '../shared/spawn-permissions'
 import { type SpawnRequest, spawnRequestSchema } from '../shared/spawn-schema'
 import {
   queryModelComparison as queryAnalyticsModels,
@@ -870,21 +871,24 @@ export function createRouter(options: RouteOptions): Hono {
     }
     const body = parsed.data
 
-    // Benevolent trust check for MCP callers (X-Caller-Session header).
-    // HTTP-specific: WS handlers identify the caller from ws.data.sessionId instead.
+    // Build caller context for the unified permission gate. MCP callers
+    // identify themselves via X-Caller-Session; everything else is dashboard HTTP.
     const callerSessionId = c.req.header('X-Caller-Session')
-    if (callerSessionId) {
-      const callerSess = sessionStore.getSession(callerSessionId)
-      const callerTrust = callerSess?.cwd ? getProjectSettings(callerSess.cwd)?.trustLevel : undefined
-      if (callerTrust !== 'benevolent') {
-        return c.json({ error: 'Spawn requires benevolent trust level' }, 403)
-      }
+    const callerSess = callerSessionId ? sessionStore.getSession(callerSessionId) : null
+    const callerCwd = callerSess?.cwd ?? null
+    const callerTrust = callerCwd ? mapProjectTrust(getProjectSettings(callerCwd)?.trustLevel) : 'trusted'
+    const callerContext: SpawnCallerContext = {
+      kind: callerSessionId ? 'mcp' : 'http',
+      hasSpawnPermission: true, // already validated by httpHasPermission above
+      trustLevel: callerTrust,
+      cwd: callerCwd,
     }
 
     const result = await dispatchSpawn(body, {
       sessions: sessionStore,
       getProjectSettings,
       getGlobalSettings,
+      callerContext,
       rendezvousCallerSessionId: callerSessionId ?? null,
     })
 

--- a/src/concentrator/routes.ts
+++ b/src/concentrator/routes.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path'
 import { Hono } from 'hono'
 import type { ListDirsResult, SendInput, Session, SpawnResult, TeamInfo } from '../shared/protocol'
 import { generateSessionName } from '../shared/session-names'
+import { spawnRequestSchema } from '../shared/spawn-schema'
 import {
   queryModelComparison as queryAnalyticsModels,
   querySummary as queryAnalyticsSummary,
@@ -852,31 +853,11 @@ export function createRouter(options: RouteOptions): Hono {
     const agent = sessionStore.getAgent()
     if (!agent) return c.json({ error: 'No host agent connected' }, 503)
 
-    const body = await c.req.json<{
-      cwd: string
-      mkdir?: boolean
-      mode?: 'fresh' | 'resume'
-      resumeId?: string
-      headless?: boolean
-      bare?: boolean
-      repl?: boolean
-      name?: string
-      model?: string
-      effort?: string
-      permissionMode?: string
-      autocompactPct?: number
-      maxBudgetUsd?: number
-      // Ad-hoc task runner fields
-      prompt?: string
-      adHoc?: boolean
-      adHocTaskId?: string
-      leaveRunning?: boolean
-      worktree?: string
-      env?: Record<string, string>
-      // Launch job correlation
-      jobId?: string
-    }>()
-    if (!body.cwd || typeof body.cwd !== 'string') return c.json({ error: 'Missing cwd field' }, 400)
+    const parsed = spawnRequestSchema.safeParse(await c.req.json())
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.message, issues: parsed.error.issues }, 400)
+    }
+    const body = parsed.data
     if (body.mode === 'resume' && !body.resumeId) return c.json({ error: 'resumeId required for resume mode' }, 400)
 
     // Benevolent trust check for MCP callers (X-Caller-Session header)

--- a/src/concentrator/routes.ts
+++ b/src/concentrator/routes.ts
@@ -17,7 +17,6 @@ import {
 import { join } from 'node:path'
 import { Hono } from 'hono'
 import type { ListDirsResult, SendInput, Session, SpawnResult, TeamInfo } from '../shared/protocol'
-import { generateSessionName } from '../shared/session-names'
 import { resolveSpawnConfig } from '../shared/spawn-defaults'
 import { type SpawnRequest, spawnRequestSchema } from '../shared/spawn-schema'
 import {
@@ -70,6 +69,7 @@ import {
   shareToGrants,
   validateShare,
 } from './shares'
+import { dispatchSpawn } from './spawn-dispatch'
 import { UI_HTML } from './ui'
 
 // ─── Image/Blob Store (disk-only, survives restarts) ────────────────────
@@ -863,17 +863,15 @@ export function createRouter(options: RouteOptions): Hono {
   app.post('/api/spawn', async c => {
     if (!httpHasPermission(c.req.raw, 'spawn', '*'))
       return c.json({ error: 'Forbidden: spawn permission required' }, 403)
-    const agent = sessionStore.getAgent()
-    if (!agent) return c.json({ error: 'No host agent connected' }, 503)
 
     const parsed = spawnRequestSchema.safeParse(await c.req.json())
     if (!parsed.success) {
       return c.json({ error: parsed.error.message, issues: parsed.error.issues }, 400)
     }
     const body = parsed.data
-    if (body.mode === 'resume' && !body.resumeId) return c.json({ error: 'resumeId required for resume mode' }, 400)
 
-    // Benevolent trust check for MCP callers (X-Caller-Session header)
+    // Benevolent trust check for MCP callers (X-Caller-Session header).
+    // HTTP-specific: WS handlers identify the caller from ws.data.sessionId instead.
     const callerSessionId = c.req.header('X-Caller-Session')
     if (callerSessionId) {
       const callerSess = sessionStore.getSession(callerSessionId)
@@ -883,134 +881,18 @@ export function createRouter(options: RouteOptions): Hono {
       }
     }
 
-    const requestId = randomUUID()
-    const wrapperId = randomUUID()
-    const jobId = body.jobId
-
-    // Register launch job if dashboard provided a jobId
-    if (jobId) {
-      sessionStore.createJob(jobId, wrapperId)
-    }
-
-    const cwdLabel = body.cwd.split('/').pop() || body.cwd
-    if (body.adHoc) {
-      console.log(
-        `[ad-hoc] Spawn request: ${cwdLabel} task=${body.adHocTaskId || 'none'} wrapper=${wrapperId.slice(0, 8)} prompt=${body.prompt?.length || 0}chars worktree=${body.worktree || 'none'}`,
-      )
-    }
-
-    const result = await new Promise<SpawnResult>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        sessionStore.removeSpawnListener(requestId)
-        reject(new Error('Spawn timed out (15s)'))
-      }, 15000)
-
-      sessionStore.addSpawnListener(requestId, msg => {
-        clearTimeout(timeout)
-        resolve(msg as SpawnResult)
-      })
-
-      // Resolve defaults (explicit > project > global > undefined)
-      const projSettings = getProjectSettings(body.cwd)
-      const globalSettings = getGlobalSettings()
-      const resolved = resolveSpawnConfig(body, projSettings, globalSettings)
-      const { headless, model, effort, permissionMode, autocompactPct, maxBudgetUsd, bare, repl } = resolved
-
-      // Store launch config so it can be reused on revive
-      sessionStore.setPendingLaunchConfig(wrapperId, {
-        headless,
-        model,
-        effort,
-        bare: bare || false,
-        repl: repl || false,
-        permissionMode,
-        autocompactPct,
-        maxBudgetUsd,
-        env: body.env || undefined,
-      })
-
-      agent.send(
-        JSON.stringify({
-          type: 'spawn',
-          requestId,
-          cwd: body.cwd,
-          wrapperId,
-          jobId,
-          mkdir: body.mkdir || false,
-          mode: body.adHoc ? 'fresh' : body.mode || 'fresh',
-          resumeId: body.resumeId,
-          headless,
-          effort,
-          model,
-          bare: bare || false,
-          repl: repl || false,
-          sessionName:
-            body.name?.trim() ||
-            generateSessionName(
-              new Set(
-                sessionStore
-                  .getAllSessions()
-                  .map((s: Session) => s.title)
-                  .filter(Boolean) as string[],
-              ),
-            ),
-          permissionMode,
-          autocompactPct,
-          maxBudgetUsd,
-          // Ad-hoc fields
-          prompt: body.prompt || undefined,
-          adHoc: body.adHoc || undefined,
-          adHocTaskId: body.adHocTaskId || undefined,
-          leaveRunning: body.leaveRunning || undefined,
-          worktree: body.worktree || undefined,
-          env: body.env || undefined,
-        }),
-      )
+    const result = await dispatchSpawn(body, {
+      sessions: sessionStore,
+      getProjectSettings,
+      getGlobalSettings,
+      rendezvousCallerSessionId: callerSessionId ?? null,
     })
 
-    if (!result.success) {
-      if (body.adHoc) console.log(`[ad-hoc] Spawn FAILED: ${result.error || 'unknown'} (${cwdLabel})`)
-      return c.json({ error: result.error || 'Spawn failed' }, 500)
+    if (!result.ok) {
+      const status = (result.statusCode ?? 500) as 400 | 403 | 500 | 503
+      return c.json({ error: result.error }, status)
     }
-    if (body.adHoc) console.log(`[ad-hoc] Spawn OK: wrapper=${wrapperId.slice(0, 8)} tmux=${result.tmuxSession}`)
-
-    // Register rendezvous: wait for the spawned wrapper to connect (up to 2 min)
-    if (callerSessionId) {
-      // Don't block the HTTP response - caller gets immediate success + wrapperId.
-      // Rendezvous resolves async and delivers to caller via inter-session channel.
-      sessionStore
-        .addRendezvous(wrapperId, callerSessionId, body.cwd, 'spawn')
-        .then(session => {
-          // Deliver session metadata to caller via their WS connection
-          const callerWs = sessionStore.getSessionSocket(callerSessionId)
-          if (callerWs) {
-            callerWs.send(
-              JSON.stringify({
-                type: 'spawn_ready',
-                sessionId: session.id,
-                cwd: session.cwd,
-                wrapperId,
-                session,
-              }),
-            )
-          }
-        })
-        .catch(err => {
-          const callerWs = sessionStore.getSessionSocket(callerSessionId)
-          if (callerWs) {
-            callerWs.send(
-              JSON.stringify({
-                type: 'spawn_timeout',
-                wrapperId,
-                cwd: body.cwd,
-                error: typeof err === 'string' ? err : 'Spawn rendezvous timed out',
-              }),
-            )
-          }
-        })
-    }
-
-    return c.json({ success: true, wrapperId, jobId, tmuxSession: result.tmuxSession })
+    return c.json({ success: true, wrapperId: result.wrapperId, jobId: result.jobId, tmuxSession: result.tmuxSession })
   })
 
   // ─── Directory listing (agent relay) ───────────────────────────────

--- a/src/concentrator/routes.ts
+++ b/src/concentrator/routes.ts
@@ -18,7 +18,8 @@ import { join } from 'node:path'
 import { Hono } from 'hono'
 import type { ListDirsResult, SendInput, Session, SpawnResult, TeamInfo } from '../shared/protocol'
 import { generateSessionName } from '../shared/session-names'
-import { spawnRequestSchema } from '../shared/spawn-schema'
+import { resolveSpawnConfig } from '../shared/spawn-defaults'
+import { type SpawnRequest, spawnRequestSchema } from '../shared/spawn-schema'
 import {
   queryModelComparison as queryAnalyticsModels,
   querySummary as queryAnalyticsSummary,
@@ -743,13 +744,25 @@ export function createRouter(options: RouteOptions): Hono {
     const lc = session.launchConfig // stored launch config from original spawn
     const name =
       session.title || getProjectSettings(session.cwd)?.label || session.cwd.split('/').pop() || sessionId.slice(0, 8)
-    // Resolve effort + model: launch config > project default > global default > undefined
+    // Resolve defaults: launch config > project > global > undefined
     const projSettings = getProjectSettings(session.cwd)
     const globalSettings = getGlobalSettings()
-    const effortRaw = lc?.effort || projSettings?.defaultEffort || globalSettings.defaultEffort
-    const effort = effortRaw && effortRaw !== 'default' ? effortRaw : undefined
-    const model = lc?.model || projSettings?.defaultModel || globalSettings.defaultModel || undefined
-    const headless = lc?.headless ?? (projSettings?.defaultLaunchMode || globalSettings.defaultLaunchMode) !== 'pty'
+    const resolved = resolveSpawnConfig(
+      {
+        cwd: session.cwd,
+        headless: lc?.headless,
+        model: lc?.model as SpawnRequest['model'] | undefined,
+        effort: lc?.effort as SpawnRequest['effort'] | undefined,
+        bare: lc?.bare,
+        repl: lc?.repl,
+        permissionMode: lc?.permissionMode as SpawnRequest['permissionMode'] | undefined,
+        autocompactPct: lc?.autocompactPct,
+        maxBudgetUsd: lc?.maxBudgetUsd,
+      },
+      projSettings,
+      globalSettings,
+    )
+    const { headless, model, effort, bare, repl, permissionMode, autocompactPct, maxBudgetUsd } = resolved
 
     agent.send(
       JSON.stringify({
@@ -762,11 +775,11 @@ export function createRouter(options: RouteOptions): Hono {
         effort,
         model,
         sessionName: session.title || undefined,
-        bare: lc?.bare || undefined,
-        repl: lc?.repl || undefined,
-        permissionMode: lc?.permissionMode || undefined,
-        autocompactPct: lc?.autocompactPct || session.autocompactPct,
-        maxBudgetUsd: lc?.maxBudgetUsd || session.maxBudgetUsd,
+        bare: bare || undefined,
+        repl: repl || undefined,
+        permissionMode,
+        autocompactPct: autocompactPct ?? session.autocompactPct,
+        maxBudgetUsd: maxBudgetUsd ?? session.maxBudgetUsd,
         adHocWorktree: session.adHocWorktree || undefined,
         env: lc?.env || undefined,
       }),
@@ -897,29 +910,22 @@ export function createRouter(options: RouteOptions): Hono {
         resolve(msg as SpawnResult)
       })
 
-      // Resolve headless: ad-hoc always headless > explicit override > project default > global setting
+      // Resolve defaults (explicit > project > global > undefined)
       const projSettings = getProjectSettings(body.cwd)
       const globalSettings = getGlobalSettings()
-      const headless = body.adHoc
-        ? true
-        : (body.headless ?? (projSettings?.defaultLaunchMode || globalSettings.defaultLaunchMode) !== 'pty')
-
-      // Resolve effort + model: explicit body override > project default > global default > undefined
-      const effortRaw = body.effort || projSettings?.defaultEffort || globalSettings.defaultEffort
-      const effort = effortRaw && effortRaw !== 'default' ? effortRaw : undefined
-      const modelRaw = body.model || projSettings?.defaultModel || globalSettings.defaultModel
-      const model = modelRaw || undefined
+      const resolved = resolveSpawnConfig(body, projSettings, globalSettings)
+      const { headless, model, effort, permissionMode, autocompactPct, maxBudgetUsd, bare, repl } = resolved
 
       // Store launch config so it can be reused on revive
       sessionStore.setPendingLaunchConfig(wrapperId, {
         headless,
         model,
         effort,
-        bare: body.bare || false,
-        repl: body.repl || false,
-        permissionMode: body.adHoc ? 'bypassPermissions' : body.permissionMode || undefined,
-        autocompactPct: body.autocompactPct || undefined,
-        maxBudgetUsd: body.maxBudgetUsd || undefined,
+        bare: bare || false,
+        repl: repl || false,
+        permissionMode,
+        autocompactPct,
+        maxBudgetUsd,
         env: body.env || undefined,
       })
 
@@ -936,8 +942,8 @@ export function createRouter(options: RouteOptions): Hono {
           headless,
           effort,
           model,
-          bare: body.bare || false,
-          repl: body.repl || false,
+          bare: bare || false,
+          repl: repl || false,
           sessionName:
             body.name?.trim() ||
             generateSessionName(
@@ -948,9 +954,9 @@ export function createRouter(options: RouteOptions): Hono {
                   .filter(Boolean) as string[],
               ),
             ),
-          permissionMode: body.adHoc ? 'bypassPermissions' : body.permissionMode || undefined,
-          autocompactPct: body.autocompactPct || undefined,
-          maxBudgetUsd: body.maxBudgetUsd || undefined,
+          permissionMode,
+          autocompactPct,
+          maxBudgetUsd,
           // Ad-hoc fields
           prompt: body.prompt || undefined,
           adHoc: body.adHoc || undefined,

--- a/src/concentrator/session-store.ts
+++ b/src/concentrator/session-store.ts
@@ -202,12 +202,32 @@ export interface SessionStore {
   resolveFile: (requestId: string, result: unknown) => boolean
   // Launch jobs (request-scoped event channels for spawn/revive progress)
   createJob: (jobId: string, wrapperId: string) => void
+  recordJobConfig: (jobId: string, config: Record<string, unknown>) => void
   subscribeJob: (jobId: string, ws: ServerWebSocket<unknown>) => boolean
   unsubscribeJob: (jobId: string, ws: ServerWebSocket<unknown>) => void
   forwardJobEvent: (jobId: string, msg: Record<string, unknown>) => void
   completeJob: (wrapperId: string, sessionId: string) => void
   failJob: (jobId: string, error: string) => void
   getJobByWrapper: (wrapperId: string) => string | undefined
+  getJobDiagnostics: (jobId: string) => {
+    jobId: string
+    wrapperId: string
+    sessionId: string | null
+    completed: boolean
+    failed: boolean
+    error: string | null
+    createdAt: number
+    endedAt: number | null
+    elapsedMs: number
+    config: Record<string, unknown> | null
+    events: {
+      type: string
+      step?: string
+      status?: string
+      detail?: string | null
+      t: number
+    }[]
+  } | null
   cleanupJobSubscriber: (ws: ServerWebSocket<unknown>) => void
   // Session rendezvous (spawn/revive callback)
   addRendezvous: (
@@ -2897,11 +2917,31 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
   // Dashboard subscribes to a jobId before spawning/reviving.
   // Agent sends launch_log events tagged with jobId.
   // Concentrator forwards to subscribers. Completes when session connects.
+  //
+  // We also accumulate events/state on the job so MCP callers (or any other
+  // late subscriber) can fetch a full diagnostic snapshot via getJobDiagnostics
+  // without having to tail the websocket in real time.
+  interface LaunchJobEvent {
+    type: string
+    step?: string
+    status?: string
+    detail?: string | null
+    t: number
+  }
   interface LaunchJob {
     jobId: string
     wrapperId: string
     subscribers: Set<ServerWebSocket<unknown>>
     createdAt: number
+    events: LaunchJobEvent[]
+    completed: boolean
+    failed: boolean
+    error: string | null
+    sessionId: string | null
+    // Snapshot of the spawn request config (sans the heavy prompt). Recorded
+    // via recordJobConfig() after dispatchSpawn resolves request defaults.
+    config: Record<string, unknown> | null
+    endedAt: number | null
   }
   const launchJobs = new Map<string, LaunchJob>() // jobId -> job
   const wrapperToJob = new Map<string, string>() // wrapperId -> jobId
@@ -2913,16 +2953,46 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
       // Dashboard pre-subscribed before spawn HTTP returned - update wrapperId
       existing.wrapperId = wrapperId
     } else {
-      launchJobs.set(jobId, { jobId, wrapperId, subscribers: new Set(), createdAt: Date.now() })
+      launchJobs.set(jobId, {
+        jobId,
+        wrapperId,
+        subscribers: new Set(),
+        createdAt: Date.now(),
+        events: [],
+        completed: false,
+        failed: false,
+        error: null,
+        sessionId: null,
+        config: null,
+        endedAt: null,
+      })
     }
     wrapperToJob.set(wrapperId, jobId)
+  }
+
+  function recordJobConfig(jobId: string, config: Record<string, unknown>): void {
+    const job = launchJobs.get(jobId)
+    if (!job) return
+    job.config = config
   }
 
   function subscribeJob(jobId: string, ws: ServerWebSocket<unknown>): boolean {
     const job = launchJobs.get(jobId)
     if (!job) {
       // Job not created yet - create a placeholder (dashboard subscribes before HTTP spawn returns)
-      launchJobs.set(jobId, { jobId, wrapperId: '', subscribers: new Set([ws]), createdAt: Date.now() })
+      launchJobs.set(jobId, {
+        jobId,
+        wrapperId: '',
+        subscribers: new Set([ws]),
+        createdAt: Date.now(),
+        events: [],
+        completed: false,
+        failed: false,
+        error: null,
+        sessionId: null,
+        config: null,
+        endedAt: null,
+      })
       return true
     }
     job.subscribers.add(ws)
@@ -2940,6 +3010,16 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
   function forwardJobEvent(jobId: string, msg: Record<string, unknown>): void {
     const job = launchJobs.get(jobId)
     if (!job) return
+    // Persist into the job so late subscribers (MCP get_spawn_diagnostics, etc.)
+    // can fetch the full event history even after the live stream has moved on.
+    const t = typeof msg.t === 'number' ? msg.t : Date.now()
+    job.events.push({
+      type: String(msg.type ?? 'unknown'),
+      step: typeof msg.step === 'string' ? msg.step : undefined,
+      status: typeof msg.status === 'string' ? msg.status : undefined,
+      detail: typeof msg.detail === 'string' ? msg.detail : msg.detail === null ? null : undefined,
+      t,
+    })
     const payload = JSON.stringify(msg)
     for (const ws of job.subscribers) {
       try {
@@ -2954,6 +3034,9 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
     const job = launchJobs.get(jobId)
     if (!job) return
 
+    job.completed = true
+    job.sessionId = sessionId
+    job.endedAt = Date.now()
     forwardJobEvent(jobId, { type: 'job_complete', jobId, sessionId, wrapperId })
 
     // Cleanup after a short delay (let dashboard process the completion)
@@ -2964,14 +3047,55 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
   }
 
   function failJob(jobId: string, error: string): void {
+    const job = launchJobs.get(jobId)
+    if (job) {
+      job.failed = true
+      job.error = error
+      job.endedAt = Date.now()
+    }
     forwardJobEvent(jobId, { type: 'job_failed', jobId, error })
     // Cleanup after delay
-    const job = launchJobs.get(jobId)
     if (job) {
       setTimeout(() => {
         launchJobs.delete(jobId)
         if (job.wrapperId) wrapperToJob.delete(job.wrapperId)
       }, 30_000)
+    }
+  }
+
+  /**
+   * Return a diagnostics snapshot for a job, or null if the job is unknown /
+   * already expired. Shape matches SpawnDiagnostics (built client-side via
+   * buildSpawnDiagnostics) but left loose here so we don't import UI types.
+   */
+  function getJobDiagnostics(jobId: string): {
+    jobId: string
+    wrapperId: string
+    sessionId: string | null
+    completed: boolean
+    failed: boolean
+    error: string | null
+    createdAt: number
+    endedAt: number | null
+    elapsedMs: number
+    config: Record<string, unknown> | null
+    events: LaunchJobEvent[]
+  } | null {
+    const job = launchJobs.get(jobId)
+    if (!job) return null
+    const now = Date.now()
+    return {
+      jobId: job.jobId,
+      wrapperId: job.wrapperId,
+      sessionId: job.sessionId,
+      completed: job.completed,
+      failed: job.failed,
+      error: job.error,
+      createdAt: job.createdAt,
+      endedAt: job.endedAt,
+      elapsedMs: (job.endedAt ?? now) - job.createdAt,
+      config: job.config,
+      events: job.events,
     }
   }
 
@@ -3285,12 +3409,14 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
     getBgTaskOutput,
     broadcastSessionUpdate,
     createJob,
+    recordJobConfig,
     subscribeJob,
     unsubscribeJob,
     forwardJobEvent,
     completeJob,
     failJob,
     getJobByWrapper,
+    getJobDiagnostics,
     cleanupJobSubscriber,
     addSpawnListener,
     removeSpawnListener,

--- a/src/concentrator/spawn-dispatch.ts
+++ b/src/concentrator/spawn-dispatch.ts
@@ -117,6 +117,31 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
     const resolved = resolveSpawnConfig(req, projSettings, globalSettings)
     const { headless, model, effort, permissionMode, autocompactPct, maxBudgetUsd, bare, repl } = resolved
 
+    // Record the resolved config on the job so MCP get_spawn_diagnostics can
+    // return it later -- we intentionally drop the prompt (can be large / PII)
+    // and the env map (sensitive values live there; diagnostics builder
+    // redacts known-secret keys).
+    if (jobId) {
+      deps.sessions.recordJobConfig(jobId, {
+        cwd: req.cwd,
+        adHoc: req.adHoc,
+        adHocTaskId: req.adHocTaskId,
+        worktree: req.worktree,
+        mkdir: req.mkdir,
+        mode: req.adHoc ? 'fresh' : req.mode || 'fresh',
+        headless,
+        model,
+        effort,
+        bare,
+        repl,
+        permissionMode,
+        autocompactPct,
+        maxBudgetUsd,
+        leaveRunning: req.leaveRunning,
+        name: req.name,
+      })
+    }
+
     deps.sessions.setPendingLaunchConfig(wrapperId, {
       headless,
       model,

--- a/src/concentrator/spawn-dispatch.ts
+++ b/src/concentrator/spawn-dispatch.ts
@@ -1,0 +1,177 @@
+/**
+ * Shared spawn dispatch logic.
+ *
+ * Single source of truth for "send a spawn to the host agent, wait for ack,
+ * register pending launch config, optionally register an MCP-caller rendezvous".
+ *
+ * Called from:
+ * - HTTP `/api/spawn` route (src/concentrator/routes.ts)
+ * - WS `spawn_request` handler (src/concentrator/handlers/spawn.ts)
+ * - WS `channel_spawn` handler (src/concentrator/handlers/inter-session.ts)
+ *
+ * Every caller has already enforced its own permission/trust check BEFORE
+ * invoking dispatchSpawn -- this function does NOT re-check. It trusts the
+ * SpawnRequest is valid and the caller is authorized.
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { ProjectSettings, Session, SpawnResult } from '../shared/protocol'
+import { generateSessionName } from '../shared/session-names'
+import { resolveSpawnConfig } from '../shared/spawn-defaults'
+import type { SpawnRequest } from '../shared/spawn-schema'
+import type { GlobalSettings } from './global-settings'
+import type { SessionStore } from './session-store'
+
+export type SpawnDispatchDeps = {
+  sessions: SessionStore
+  getProjectSettings: (cwd: string) => ProjectSettings | null
+  getGlobalSettings: () => GlobalSettings
+  /** If set, register a rendezvous so the caller session is notified when the spawned wrapper connects. */
+  rendezvousCallerSessionId?: string | null
+}
+
+export type SpawnDispatchResult =
+  | { ok: true; wrapperId: string; jobId?: string; tmuxSession?: string }
+  | { ok: false; error: string; statusCode?: number }
+
+/**
+ * Send a spawn request to the host agent, await ack, register pending launch config.
+ *
+ * Does NOT enforce permissions - callers must check first. Does NOT validate the
+ * SpawnRequest - callers should have parsed it via spawnRequestSchema already.
+ */
+export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps): Promise<SpawnDispatchResult> {
+  const agent = deps.sessions.getAgent()
+  if (!agent) return { ok: false, error: 'No host agent connected', statusCode: 503 }
+
+  if (req.mode === 'resume' && !req.resumeId) {
+    return { ok: false, error: 'resumeId required for resume mode', statusCode: 400 }
+  }
+
+  const requestId = randomUUID()
+  const wrapperId = randomUUID()
+  const jobId = req.jobId
+
+  if (jobId) {
+    deps.sessions.createJob(jobId, wrapperId)
+  }
+
+  const cwdLabel = req.cwd.split('/').pop() || req.cwd
+  if (req.adHoc) {
+    console.log(
+      `[ad-hoc] Spawn request: ${cwdLabel} task=${req.adHocTaskId || 'none'} wrapper=${wrapperId.slice(0, 8)} prompt=${req.prompt?.length || 0}chars worktree=${req.worktree || 'none'}`,
+    )
+  }
+
+  const result = await new Promise<SpawnResult>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      deps.sessions.removeSpawnListener(requestId)
+      reject(new Error('Spawn timed out (15s)'))
+    }, 15000)
+
+    deps.sessions.addSpawnListener(requestId, msg => {
+      clearTimeout(timeout)
+      resolve(msg as SpawnResult)
+    })
+
+    const projSettings = deps.getProjectSettings(req.cwd)
+    const globalSettings = deps.getGlobalSettings()
+    const resolved = resolveSpawnConfig(req, projSettings, globalSettings)
+    const { headless, model, effort, permissionMode, autocompactPct, maxBudgetUsd, bare, repl } = resolved
+
+    deps.sessions.setPendingLaunchConfig(wrapperId, {
+      headless,
+      model,
+      effort,
+      bare: bare || false,
+      repl: repl || false,
+      permissionMode,
+      autocompactPct,
+      maxBudgetUsd,
+      env: req.env || undefined,
+    })
+
+    agent.send(
+      JSON.stringify({
+        type: 'spawn',
+        requestId,
+        cwd: req.cwd,
+        wrapperId,
+        jobId,
+        mkdir: req.mkdir || false,
+        mode: req.adHoc ? 'fresh' : req.mode || 'fresh',
+        resumeId: req.resumeId,
+        headless,
+        effort,
+        model,
+        bare: bare || false,
+        repl: repl || false,
+        sessionName:
+          req.name?.trim() ||
+          generateSessionName(
+            new Set(
+              deps.sessions
+                .getAllSessions()
+                .map((s: Session) => s.title)
+                .filter(Boolean) as string[],
+            ),
+          ),
+        permissionMode,
+        autocompactPct,
+        maxBudgetUsd,
+        prompt: req.prompt || undefined,
+        adHoc: req.adHoc || undefined,
+        adHocTaskId: req.adHocTaskId || undefined,
+        leaveRunning: req.leaveRunning || undefined,
+        worktree: req.worktree || undefined,
+        env: req.env || undefined,
+      }),
+    )
+  }).catch((err: unknown) => {
+    return {
+      type: 'spawn_result',
+      requestId,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    } as SpawnResult
+  })
+
+  if (!result.success) {
+    if (req.adHoc) console.log(`[ad-hoc] Spawn FAILED: ${result.error || 'unknown'} (${cwdLabel})`)
+    return { ok: false, error: result.error || 'Spawn failed', statusCode: 500 }
+  }
+  if (req.adHoc) console.log(`[ad-hoc] Spawn OK: wrapper=${wrapperId.slice(0, 8)} tmux=${result.tmuxSession}`)
+
+  const callerSessionId = deps.rendezvousCallerSessionId
+  if (callerSessionId) {
+    // Don't block the response -- caller gets immediate success + wrapperId.
+    // Rendezvous resolves async and pushes spawn_ready / spawn_timeout.
+    deps.sessions
+      .addRendezvous(wrapperId, callerSessionId, req.cwd, 'spawn')
+      .then(session => {
+        const callerWs = deps.sessions.getSessionSocket(callerSessionId)
+        callerWs?.send(
+          JSON.stringify({
+            type: 'spawn_ready',
+            sessionId: session.id,
+            cwd: session.cwd,
+            wrapperId,
+            session,
+          }),
+        )
+      })
+      .catch(err => {
+        const callerWs = deps.sessions.getSessionSocket(callerSessionId)
+        callerWs?.send(
+          JSON.stringify({
+            type: 'spawn_timeout',
+            wrapperId,
+            cwd: req.cwd,
+            error: typeof err === 'string' ? err : 'Spawn rendezvous timed out',
+          }),
+        )
+      })
+  }
+
+  return { ok: true, wrapperId, jobId, tmuxSession: result.tmuxSession }
+}

--- a/src/concentrator/spawn-dispatch.ts
+++ b/src/concentrator/spawn-dispatch.ts
@@ -18,6 +18,8 @@ import { randomUUID } from 'node:crypto'
 import type { ProjectSettings, Session, SpawnResult } from '../shared/protocol'
 import { generateSessionName } from '../shared/session-names'
 import { resolveSpawnConfig } from '../shared/spawn-defaults'
+import { deriveSessionName } from '../shared/spawn-naming'
+import { assertSpawnAllowed, type SpawnCallerContext, SpawnPermissionError } from '../shared/spawn-permissions'
 import type { SpawnRequest } from '../shared/spawn-schema'
 import type { GlobalSettings } from './global-settings'
 import type { SessionStore } from './session-store'
@@ -26,6 +28,8 @@ export type SpawnDispatchDeps = {
   sessions: SessionStore
   getProjectSettings: (cwd: string) => ProjectSettings | null
   getGlobalSettings: () => GlobalSettings
+  /** Caller context for the unified permission gate. */
+  callerContext: SpawnCallerContext
   /** If set, register a rendezvous so the caller session is notified when the spawned wrapper connects. */
   rendezvousCallerSessionId?: string | null
 }
@@ -41,6 +45,15 @@ export type SpawnDispatchResult =
  * SpawnRequest - callers should have parsed it via spawnRequestSchema already.
  */
 export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps): Promise<SpawnDispatchResult> {
+  try {
+    assertSpawnAllowed(deps.callerContext, req)
+  } catch (err) {
+    if (err instanceof SpawnPermissionError) {
+      return { ok: false, error: err.message, statusCode: 403 }
+    }
+    throw err
+  }
+
   const agent = deps.sessions.getAgent()
   if (!agent) return { ok: false, error: 'No host agent connected', statusCode: 503 }
 
@@ -107,7 +120,7 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
         bare: bare || false,
         repl: repl || false,
         sessionName:
-          req.name?.trim() ||
+          deriveSessionName(req) ??
           generateSessionName(
             new Set(
               deps.sessions

--- a/src/concentrator/spawn-dispatch.ts
+++ b/src/concentrator/spawn-dispatch.ts
@@ -15,7 +15,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import type { ProjectSettings, Session, SpawnResult } from '../shared/protocol'
+import type { LaunchProgressEvent, LaunchStep, ProjectSettings, Session, SpawnResult } from '../shared/protocol'
 import { generateSessionName } from '../shared/session-names'
 import { resolveSpawnConfig } from '../shared/spawn-defaults'
 import { deriveSessionName } from '../shared/spawn-naming'
@@ -23,6 +23,28 @@ import { assertSpawnAllowed, type SpawnCallerContext, SpawnPermissionError } fro
 import type { SpawnRequest } from '../shared/spawn-schema'
 import type { GlobalSettings } from './global-settings'
 import type { SessionStore } from './session-store'
+
+/**
+ * Emit a first-class launch_progress event to all subscribers of the job.
+ * No-op if jobId is undefined (callers that dispatch without tracking a job).
+ */
+function emitProgress(
+  sessions: SessionStore,
+  jobId: string | undefined,
+  step: LaunchStep,
+  status: LaunchProgressEvent['status'],
+  extra?: Partial<LaunchProgressEvent>,
+): void {
+  if (!jobId) return
+  sessions.forwardJobEvent(jobId, {
+    type: 'launch_progress',
+    jobId,
+    step,
+    status,
+    t: Date.now(),
+    ...extra,
+  })
+}
 
 export type SpawnDispatchDeps = {
   sessions: SessionStore
@@ -67,6 +89,7 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
 
   if (jobId) {
     deps.sessions.createJob(jobId, wrapperId)
+    emitProgress(deps.sessions, jobId, 'job_created', 'done', { wrapperId })
   }
 
   const cwdLabel = req.cwd.split('/').pop() || req.cwd
@@ -86,6 +109,8 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
       clearTimeout(timeout)
       resolve(msg as SpawnResult)
     })
+
+    emitProgress(deps.sessions, jobId, 'spawn_sent', 'active')
 
     const projSettings = deps.getProjectSettings(req.cwd)
     const globalSettings = deps.getGlobalSettings()
@@ -151,8 +176,10 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
 
   if (!result.success) {
     if (req.adHoc) console.log(`[ad-hoc] Spawn FAILED: ${result.error || 'unknown'} (${cwdLabel})`)
+    emitProgress(deps.sessions, jobId, 'failed', 'error', { error: result.error || 'Spawn failed' })
     return { ok: false, error: result.error || 'Spawn failed', statusCode: 500 }
   }
+  emitProgress(deps.sessions, jobId, 'agent_acked', 'done', { detail: result.tmuxSession })
   if (req.adHoc) console.log(`[ad-hoc] Spawn OK: wrapper=${wrapperId.slice(0, 8)} tmux=${result.tmuxSession}`)
 
   const callerSessionId = deps.rendezvousCallerSessionId
@@ -162,6 +189,10 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
     deps.sessions
       .addRendezvous(wrapperId, callerSessionId, req.cwd, 'spawn')
       .then(session => {
+        emitProgress(deps.sessions, jobId, 'session_connected', 'done', {
+          sessionId: session.id,
+          wrapperId,
+        })
         const callerWs = deps.sessions.getSessionSocket(callerSessionId)
         callerWs?.send(
           JSON.stringify({
@@ -174,13 +205,15 @@ export async function dispatchSpawn(req: SpawnRequest, deps: SpawnDispatchDeps):
         )
       })
       .catch(err => {
+        const errMsg = typeof err === 'string' ? err : 'Spawn rendezvous timed out'
+        emitProgress(deps.sessions, jobId, 'failed', 'error', { error: errMsg })
         const callerWs = deps.sessions.getSessionSocket(callerSessionId)
         callerWs?.send(
           JSON.stringify({
             type: 'spawn_timeout',
             wrapperId,
             cwd: req.cwd,
-            error: typeof err === 'string' ? err : 'Spawn rendezvous timed out',
+            error: errMsg,
           }),
         )
       })

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -3,6 +3,21 @@
  * Defines the message format between wrapper and concentrator
  */
 
+import type { SpawnRequest } from './spawn-schema'
+
+// Dashboard -> Concentrator: spawn request (WS equivalent of POST /api/spawn)
+export type SpawnRequestMessage = { type: 'spawn_request' } & SpawnRequest
+
+// Concentrator -> Dashboard: ack for spawn_request (correlated by jobId)
+export interface SpawnRequestAck {
+  type: 'spawn_request_ack'
+  ok: boolean
+  jobId?: string
+  wrapperId?: string
+  tmuxSession?: string
+  error?: string
+}
+
 // Wrapper -> Concentrator messages
 export interface HookEvent {
   type: 'hook'

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1014,6 +1014,36 @@ export interface LaunchLog {
   t: number
 }
 
+/** Structured launch lifecycle step (concentrator -> dashboard, first-class) */
+export type LaunchStep =
+  | 'job_created'
+  | 'spawn_sent'
+  | 'agent_acked'
+  | 'wrapper_booted'
+  | 'session_connected'
+  | 'prompt_submitted'
+  | 'running'
+  | 'completed'
+  | 'failed'
+
+/**
+ * Concentrator -> Dashboard: first-class launch progress event.
+ * Emitted at each lifecycle step of a spawn/revive job so clients (dashboard,
+ * MCP callers) see real progress instead of silence.
+ */
+export interface LaunchProgressEvent {
+  type: 'launch_progress'
+  jobId: string
+  step: LaunchStep
+  status: 'active' | 'done' | 'error'
+  detail?: string
+  t: number
+  wrapperId?: string
+  sessionId?: string
+  elapsed?: number
+  error?: string
+}
+
 /** Concentrator -> Dashboard: launch job completed (session connected) */
 export interface JobComplete {
   type: 'job_complete'

--- a/src/shared/spawn-defaults.test.ts
+++ b/src/shared/spawn-defaults.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import { type DefaultsSource, resolveSpawnConfig } from './spawn-defaults'
+import type { SpawnRequest } from './spawn-schema'
+
+const emptyProj: DefaultsSource = {}
+const emptyGlobal: DefaultsSource = {}
+
+describe('resolveSpawnConfig', () => {
+  describe('model', () => {
+    it('uses project default when explicit is missing', () => {
+      expect(resolveSpawnConfig({}, { defaultModel: 'sonnet' }, null).model).toBe('sonnet')
+    })
+
+    it('explicit wins over project default', () => {
+      expect(
+        resolveSpawnConfig({ model: 'opus' as SpawnRequest['model'] }, { defaultModel: 'sonnet' }, null).model,
+      ).toBe('opus')
+    })
+
+    it('project wins over global', () => {
+      expect(resolveSpawnConfig({}, { defaultModel: 'sonnet' }, { defaultModel: 'opus' }).model).toBe('sonnet')
+    })
+
+    it('falls back to global when project is empty', () => {
+      expect(resolveSpawnConfig({}, emptyProj, { defaultModel: 'opus' }).model).toBe('opus')
+    })
+
+    it('empty-string default means unset', () => {
+      expect(resolveSpawnConfig({}, null, { defaultModel: '' }).model).toBeUndefined()
+    })
+
+    it('undefined when nothing set', () => {
+      expect(resolveSpawnConfig({}, null, null).model).toBeUndefined()
+    })
+  })
+
+  describe('effort', () => {
+    it("'default' sentinel in project default means unset", () => {
+      expect(resolveSpawnConfig({}, { defaultEffort: 'default' }, null).effort).toBeUndefined()
+    })
+
+    it('respects real project effort', () => {
+      expect(resolveSpawnConfig({}, { defaultEffort: 'high' }, null).effort).toBe('high')
+    })
+
+    it("'default' sentinel at global level means unset", () => {
+      expect(resolveSpawnConfig({}, null, { defaultEffort: 'default' }).effort).toBeUndefined()
+    })
+  })
+
+  describe('permissionMode', () => {
+    it('adHoc forces bypassPermissions', () => {
+      expect(resolveSpawnConfig({ adHoc: true }, null, null).permissionMode).toBe('bypassPermissions')
+    })
+
+    it('adHoc overrides explicit permissionMode', () => {
+      expect(
+        resolveSpawnConfig({ adHoc: true, permissionMode: 'plan' as SpawnRequest['permissionMode'] }, null, null)
+          .permissionMode,
+      ).toBe('bypassPermissions')
+    })
+
+    it('respects explicit permissionMode when not adHoc', () => {
+      expect(
+        resolveSpawnConfig({ permissionMode: 'acceptEdits' as SpawnRequest['permissionMode'] }, null, null)
+          .permissionMode,
+      ).toBe('acceptEdits')
+    })
+
+    it("'default' sentinel means unset", () => {
+      expect(resolveSpawnConfig({}, { defaultPermissionMode: 'default' }, null).permissionMode).toBeUndefined()
+    })
+  })
+
+  describe('headless', () => {
+    it('adHoc always forces headless=true', () => {
+      expect(resolveSpawnConfig({ adHoc: true }, null, null).headless).toBe(true)
+    })
+
+    it('adHoc overrides global defaultLaunchMode=pty', () => {
+      expect(resolveSpawnConfig({ adHoc: true }, null, { defaultLaunchMode: 'pty' }).headless).toBe(true)
+    })
+
+    it('explicit headless=false wins when not adHoc', () => {
+      expect(resolveSpawnConfig({ headless: false }, null, { defaultLaunchMode: 'headless' }).headless).toBe(false)
+    })
+
+    it('project defaultLaunchMode=pty yields headless=false', () => {
+      expect(resolveSpawnConfig({}, { defaultLaunchMode: 'pty' }, null).headless).toBe(false)
+    })
+
+    it('defaults to headless=true when nothing set', () => {
+      expect(resolveSpawnConfig({}, null, null).headless).toBe(true)
+    })
+  })
+
+  describe('numerics (autocompactPct, maxBudgetUsd)', () => {
+    it('zero in project default means unset', () => {
+      expect(resolveSpawnConfig({}, { defaultAutocompactPct: 0 }, { defaultAutocompactPct: 80 }).autocompactPct).toBe(
+        80,
+      )
+    })
+
+    it('explicit positive wins', () => {
+      expect(resolveSpawnConfig({ autocompactPct: 50 }, { defaultAutocompactPct: 80 }, null).autocompactPct).toBe(50)
+    })
+
+    it('maxBudgetUsd falls back across levels', () => {
+      expect(resolveSpawnConfig({}, null, { defaultMaxBudgetUsd: 5 }).maxBudgetUsd).toBe(5)
+      expect(resolveSpawnConfig({}, null, { defaultMaxBudgetUsd: 0 }).maxBudgetUsd).toBeUndefined()
+    })
+  })
+
+  describe('booleans (bare, repl)', () => {
+    it('explicit false overrides project true', () => {
+      expect(resolveSpawnConfig({ bare: false }, { defaultBare: true }, null).bare).toBe(false)
+    })
+
+    it('falls back to project', () => {
+      expect(resolveSpawnConfig({}, { defaultBare: true }, null).bare).toBe(true)
+    })
+
+    it('falls back to global when project is undefined', () => {
+      expect(resolveSpawnConfig({}, null, { defaultRepl: true }).repl).toBe(true)
+    })
+  })
+
+  it('preserves other request fields untouched', () => {
+    const partial: Partial<SpawnRequest> = {
+      cwd: '/tmp/x',
+      mkdir: true,
+      prompt: 'hi',
+      worktree: 'feat-x',
+      adHoc: false,
+    }
+    const out = resolveSpawnConfig(partial, emptyProj, emptyGlobal)
+    expect(out.cwd).toBe('/tmp/x')
+    expect(out.mkdir).toBe(true)
+    expect(out.prompt).toBe('hi')
+    expect(out.worktree).toBe('feat-x')
+  })
+})

--- a/src/shared/spawn-defaults.ts
+++ b/src/shared/spawn-defaults.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical resolver for spawn request defaults.
+ *
+ * Merges `explicit > project > global > undefined` across every field that
+ * has a settings-backed default. Consumed by:
+ * - HTTP /api/spawn route (src/concentrator/routes.ts)
+ * - HTTP /sessions/:id/revive route
+ * - WS channel_spawn handler (src/concentrator/handlers/inter-session.ts)
+ *
+ * Empty strings, the `'default'` sentinel, and `0` numerics (in defaults) all
+ * mean "unset" -- callers downstream treat `undefined` as "use CC default".
+ */
+
+import type { SpawnRequest } from './spawn-schema'
+
+export type DefaultsSource = {
+  defaultModel?: string
+  defaultEffort?: string
+  defaultPermissionMode?: string
+  defaultMaxBudgetUsd?: number
+  defaultAutocompactPct?: number
+  defaultLaunchMode?: 'headless' | 'pty'
+  defaultBare?: boolean
+  defaultRepl?: boolean
+}
+
+/** Shape returned by resolveSpawnConfig -- `headless` is always concrete. */
+export type ResolvedSpawnConfig = Partial<SpawnRequest> & { headless: boolean }
+
+/**
+ * Merge spawn request defaults: explicit > project > global > undefined.
+ * Empty strings, 'default' sentinel, and 0 numerics in defaults are treated as unset.
+ */
+export function resolveSpawnConfig(
+  partial: Partial<SpawnRequest>,
+  project?: DefaultsSource | null,
+  global?: DefaultsSource | null,
+): ResolvedSpawnConfig {
+  const model = pickString(partial.model, project?.defaultModel, global?.defaultModel) as
+    | SpawnRequest['model']
+    | undefined
+  const effort = pickString(partial.effort, project?.defaultEffort, global?.defaultEffort) as
+    | SpawnRequest['effort']
+    | undefined
+  const permissionModeResolved = pickString(
+    partial.permissionMode,
+    project?.defaultPermissionMode,
+    global?.defaultPermissionMode,
+  ) as SpawnRequest['permissionMode'] | undefined
+
+  // headless: adHoc always true; otherwise explicit > project > global launch mode
+  const launchMode = project?.defaultLaunchMode || global?.defaultLaunchMode
+  const headless = partial.adHoc ? true : partial.headless !== undefined ? partial.headless : launchMode !== 'pty'
+
+  const autocompactPct = pickNumber(
+    partial.autocompactPct,
+    project?.defaultAutocompactPct,
+    global?.defaultAutocompactPct,
+  )
+  const maxBudgetUsd = pickNumber(partial.maxBudgetUsd, project?.defaultMaxBudgetUsd, global?.defaultMaxBudgetUsd)
+
+  const bare = partial.bare ?? project?.defaultBare ?? global?.defaultBare ?? undefined
+  const repl = partial.repl ?? project?.defaultRepl ?? global?.defaultRepl ?? undefined
+
+  return {
+    ...partial,
+    model,
+    effort,
+    permissionMode: partial.adHoc ? 'bypassPermissions' : permissionModeResolved,
+    headless,
+    autocompactPct,
+    maxBudgetUsd,
+    bare,
+    repl,
+  }
+}
+
+function pickString(
+  explicit: string | undefined,
+  proj: string | undefined,
+  glob: string | undefined,
+): string | undefined {
+  const out = explicit || proj || glob
+  return out && out !== 'default' ? out : undefined
+}
+
+function pickNumber(
+  explicit: number | undefined,
+  proj: number | undefined,
+  glob: number | undefined,
+): number | undefined {
+  if (explicit !== undefined && explicit > 0) return explicit
+  if (proj !== undefined && proj > 0) return proj
+  if (glob !== undefined && glob > 0) return glob
+  return undefined
+}

--- a/src/shared/spawn-diagnostics.test.ts
+++ b/src/shared/spawn-diagnostics.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { type BuildDiagnosticsInput, buildSpawnDiagnostics } from './spawn-diagnostics'
+
+function makeInput(over: Partial<BuildDiagnosticsInput> = {}): BuildDiagnosticsInput {
+  return {
+    source: 'run-task-dialog',
+    jobId: 'job-1',
+    wrapperId: 'wrap-1',
+    sessionId: 'sess-1',
+    elapsedSec: 12,
+    error: null,
+    config: { cwd: '/tmp/p', model: 'opus' },
+    steps: [{ label: 'step', status: 'done', detail: null, ts: 1 }],
+    launchEvents: [{ step: 's', status: 'ok', detail: 'd', t: 5 }],
+    launchState: { completed: true, failed: false },
+    ...over,
+  }
+}
+
+describe('buildSpawnDiagnostics', () => {
+  it('has stable envelope fields', () => {
+    const d = buildSpawnDiagnostics(makeInput())
+    expect(d.type).toBe('spawn_diagnostics')
+    expect(d.version).toBe(1)
+    expect(typeof d.time).toBe('string')
+    expect(Number.isNaN(Date.parse(d.time))).toBe(false)
+    expect(d.source).toBe('run-task-dialog')
+    expect(d.jobId).toBe('job-1')
+    expect(d.wrapperId).toBe('wrap-1')
+    expect(d.sessionId).toBe('sess-1')
+    expect(d.elapsed).toBe('12s')
+    expect(d.launchState).toEqual({ completed: true, failed: false })
+    expect(d.steps).toHaveLength(1)
+    expect(d.launchEvents).toHaveLength(1)
+  })
+
+  it('coerces null-ish ids when omitted', () => {
+    const d = buildSpawnDiagnostics(
+      makeInput({ jobId: undefined, wrapperId: undefined, sessionId: undefined, error: undefined }),
+    )
+    expect(d.jobId).toBeNull()
+    expect(d.wrapperId).toBeNull()
+    expect(d.sessionId).toBeNull()
+    expect(d.error).toBeNull()
+  })
+
+  it('redacts sensitive env keys in config', () => {
+    const d = buildSpawnDiagnostics(
+      makeInput({
+        config: {
+          cwd: '/tmp/p',
+          env: { ANTHROPIC_API_KEY: 'sk-secret', MY_VAR: 'keep-me', GITHUB_TOKEN: 'ghp_xxx' },
+        },
+      }),
+    )
+    expect(d.config.env?.ANTHROPIC_API_KEY).toBe('[redacted]')
+    expect(d.config.env?.GITHUB_TOKEN).toBe('[redacted]')
+    expect(d.config.env?.MY_VAR).toBe('keep-me')
+  })
+
+  it('does not mutate the caller config.env', () => {
+    const env = { ANTHROPIC_API_KEY: 'sk-secret' }
+    const config = { cwd: '/tmp/p', env }
+    buildSpawnDiagnostics(makeInput({ config }))
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-secret')
+  })
+
+  it('accepts mcp source', () => {
+    const d = buildSpawnDiagnostics(makeInput({ source: 'mcp' }))
+    expect(d.source).toBe('mcp')
+  })
+
+  it('carries task metadata through when provided', () => {
+    const d = buildSpawnDiagnostics(
+      makeInput({
+        task: { slug: 't-1', title: 'Ship it', status: 'open', priority: 'high', tags: ['a'] },
+      }),
+    )
+    expect(d.task?.slug).toBe('t-1')
+    expect(d.task?.title).toBe('Ship it')
+  })
+})

--- a/src/shared/spawn-diagnostics.ts
+++ b/src/shared/spawn-diagnostics.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical spawn diagnostics payload.
+ *
+ * Shared across the dashboard's "Copy diagnostics" buttons and the
+ * `get_spawn_diagnostics` MCP tool. Single JSON shape so diagnostics pasted
+ * from either side are interchangeable.
+ */
+
+import type { TaskMeta } from './spawn-prompt'
+import type { SpawnRequest } from './spawn-schema'
+
+export type DiagnosticsStep = {
+  label: string
+  status: string
+  detail: string | null
+  ts: number | null
+}
+
+export type DiagnosticsLaunchEvent = {
+  step: string
+  status: string
+  detail: string | null
+  t: number
+}
+
+export type DiagnosticsSource = 'spawn-dialog' | 'run-task-dialog' | 'mcp'
+
+export type SpawnDiagnostics = {
+  type: 'spawn_diagnostics'
+  version: 1
+  time: string
+  source: DiagnosticsSource
+  jobId: string | null
+  wrapperId: string | null
+  sessionId: string | null
+  elapsed: string
+  error: string | null
+  config: Partial<SpawnRequest>
+  steps: DiagnosticsStep[]
+  launchEvents: DiagnosticsLaunchEvent[]
+  launchState: { completed: boolean; failed: boolean }
+  task?: TaskMeta
+}
+
+export type BuildDiagnosticsInput = {
+  source: DiagnosticsSource
+  jobId?: string | null
+  wrapperId?: string | null
+  sessionId?: string | null
+  elapsedSec: number
+  error?: string | null
+  config: Partial<SpawnRequest>
+  steps: DiagnosticsStep[]
+  launchEvents: DiagnosticsLaunchEvent[]
+  launchState: { completed: boolean; failed: boolean }
+  task?: TaskMeta
+}
+
+export const SENSITIVE_DIAG_ENV_KEYS: ReadonlySet<string> = new Set([
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'SLACK_TOKEN',
+])
+
+function redactEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(env)) {
+    out[k] = SENSITIVE_DIAG_ENV_KEYS.has(k) ? '[redacted]' : v
+  }
+  return out
+}
+
+export function buildSpawnDiagnostics(input: BuildDiagnosticsInput): SpawnDiagnostics {
+  const config: Partial<SpawnRequest> = { ...input.config }
+  if (config.env) {
+    config.env = redactEnv(config.env)
+  }
+  return {
+    type: 'spawn_diagnostics',
+    version: 1,
+    time: new Date().toISOString(),
+    source: input.source,
+    jobId: input.jobId ?? null,
+    wrapperId: input.wrapperId ?? null,
+    sessionId: input.sessionId ?? null,
+    elapsed: `${input.elapsedSec}s`,
+    error: input.error ?? null,
+    config,
+    steps: input.steps,
+    launchEvents: input.launchEvents,
+    launchState: input.launchState,
+    task: input.task,
+  }
+}

--- a/src/shared/spawn-naming.test.ts
+++ b/src/shared/spawn-naming.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { deriveSessionName, sanitizeSessionName } from './spawn-naming'
+import type { TaskMeta } from './spawn-prompt'
+
+const task: TaskMeta = {
+  slug: 't-1',
+  title: 'Build the rocket',
+  status: 'open',
+  priority: 'high',
+  tags: ['alpha'],
+}
+
+describe('sanitizeSessionName', () => {
+  it('strips single and double quotes', () => {
+    expect(sanitizeSessionName(`"hello" 'world'`)).toBe('hello world')
+  })
+
+  it('collapses whitespace and trims', () => {
+    expect(sanitizeSessionName('  a\t\tb\n\nc  ')).toBe('a b c')
+  })
+
+  it('truncates to 60 characters', () => {
+    const s = 'x'.repeat(120)
+    expect(sanitizeSessionName(s)).toHaveLength(60)
+  })
+})
+
+describe('deriveSessionName', () => {
+  it('uses explicit name when provided', () => {
+    expect(deriveSessionName({ name: 'my session' })).toBe('my session')
+  })
+
+  it('prefers explicit name over task.title', () => {
+    expect(deriveSessionName({ name: 'override' }, task)).toBe('override')
+  })
+
+  it('falls back to task.title when name is absent', () => {
+    expect(deriveSessionName({}, task)).toBe('Build the rocket')
+  })
+
+  it('falls back to first non-empty line of prompt', () => {
+    const out = deriveSessionName({ prompt: '\n\nFirst real line\nsecond line' })
+    expect(out).toBe('First real line')
+  })
+
+  it('returns null when no hints are present', () => {
+    expect(deriveSessionName({})).toBeNull()
+    expect(deriveSessionName({ prompt: '' })).toBeNull()
+    expect(deriveSessionName({ prompt: '\n  \n\t\n' })).toBeNull()
+  })
+
+  it('strips quotes in derived name', () => {
+    expect(deriveSessionName({ name: `"quoted"` })).toBe('quoted')
+  })
+
+  it('truncates long task titles to 60 chars', () => {
+    const long = { ...task, title: 'x'.repeat(200) }
+    const out = deriveSessionName({}, long)
+    expect(out).toHaveLength(60)
+  })
+
+  it('ignores empty explicit name and advances to next hint', () => {
+    expect(deriveSessionName({ name: '   ' }, task)).toBe('Build the rocket')
+  })
+})

--- a/src/shared/spawn-naming.ts
+++ b/src/shared/spawn-naming.ts
@@ -1,0 +1,40 @@
+/**
+ * Derive a human-readable session label from spawn request hints.
+ *
+ * Order of preference:
+ *   1. explicit `req.name`
+ *   2. `task.title`
+ *   3. first non-empty line of `req.prompt`
+ *
+ * Returns `null` when no hint is available -- callers should fall back to
+ * the random generator in `./session-names`.
+ */
+
+import type { TaskMeta } from './spawn-prompt'
+import type { SpawnRequest } from './spawn-schema'
+
+const MAX_NAME_LEN = 60
+
+/** Strip quotes, collapse whitespace, trim, slice to {@link MAX_NAME_LEN}. */
+export function sanitizeSessionName(raw: string): string {
+  return raw.replace(/['"]/g, '').replace(/\s+/g, ' ').trim().slice(0, MAX_NAME_LEN)
+}
+
+export function deriveSessionName(req: Partial<SpawnRequest>, task?: TaskMeta): string | null {
+  if (req.name) {
+    const n = sanitizeSessionName(req.name)
+    if (n) return n
+  }
+  if (task?.title) {
+    const n = sanitizeSessionName(task.title)
+    if (n) return n
+  }
+  if (req.prompt) {
+    const firstLine = req.prompt.split('\n').find(l => l.trim().length > 0)
+    if (firstLine) {
+      const n = sanitizeSessionName(firstLine)
+      if (n) return n
+    }
+  }
+  return null
+}

--- a/src/shared/spawn-permissions.test.ts
+++ b/src/shared/spawn-permissions.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertSpawnAllowed,
+  mapProjectTrust,
+  type SpawnCallerContext,
+  SpawnPermissionError,
+  type TrustLevel,
+} from './spawn-permissions'
+import type { SpawnRequest } from './spawn-schema'
+
+function makeCtx(overrides: Partial<SpawnCallerContext> = {}): SpawnCallerContext {
+  return {
+    kind: 'http',
+    hasSpawnPermission: true,
+    trustLevel: 'trusted',
+    cwd: null,
+    ...overrides,
+  }
+}
+
+const baseReq: SpawnRequest = { cwd: '/tmp/project' }
+
+describe('assertSpawnAllowed', () => {
+  it('passes for trusted HTTP caller with base request', () => {
+    expect(() => assertSpawnAllowed(makeCtx(), baseReq)).not.toThrow()
+  })
+
+  it('denies when hasSpawnPermission is false', () => {
+    let err: unknown
+    try {
+      assertSpawnAllowed(makeCtx({ hasSpawnPermission: false }), baseReq)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(SpawnPermissionError)
+    expect((err as SpawnPermissionError).required).toBe('spawn_permission')
+  })
+
+  it('denies MCP caller without benevolent trust', () => {
+    const ctx = makeCtx({ kind: 'mcp', trustLevel: 'trusted', cwd: '/mcp/app' })
+    let err: unknown
+    try {
+      assertSpawnAllowed(ctx, baseReq)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(SpawnPermissionError)
+    expect((err as SpawnPermissionError).required).toBe('benevolent')
+  })
+
+  it('passes MCP caller with benevolent trust', () => {
+    const ctx = makeCtx({ kind: 'mcp', trustLevel: 'benevolent', cwd: '/mcp/app' })
+    expect(() => assertSpawnAllowed(ctx, baseReq)).not.toThrow()
+  })
+
+  it('denies bypassPermissions for non-benevolent caller', () => {
+    const req: SpawnRequest = { ...baseReq, permissionMode: 'bypassPermissions' }
+    let err: unknown
+    try {
+      assertSpawnAllowed(makeCtx({ trustLevel: 'trusted' }), req)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(SpawnPermissionError)
+    expect((err as SpawnPermissionError).field).toBe('permissionMode')
+    expect((err as SpawnPermissionError).required).toBe('benevolent')
+  })
+
+  it('passes bypassPermissions for benevolent caller', () => {
+    const req: SpawnRequest = { ...baseReq, permissionMode: 'bypassPermissions' }
+    expect(() => assertSpawnAllowed(makeCtx({ trustLevel: 'benevolent' }), req)).not.toThrow()
+  })
+
+  it('allows non-sensitive env override for trusted caller', () => {
+    const req: SpawnRequest = { ...baseReq, env: { MY_VAR: 'hello' } }
+    expect(() => assertSpawnAllowed(makeCtx(), req)).not.toThrow()
+  })
+
+  it('denies sensitive env override (ANTHROPIC_API_KEY) for trusted caller', () => {
+    const req: SpawnRequest = { ...baseReq, env: { ANTHROPIC_API_KEY: 'sk-xxx' } }
+    let err: unknown
+    try {
+      assertSpawnAllowed(makeCtx({ trustLevel: 'trusted' }), req)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(SpawnPermissionError)
+    expect((err as SpawnPermissionError).field).toBe('env')
+    expect((err as SpawnPermissionError).required).toBe('benevolent')
+  })
+
+  it('denies sensitive env override (PATH) for trusted caller', () => {
+    const req: SpawnRequest = { ...baseReq, env: { PATH: '/evil/bin' } }
+    expect(() => assertSpawnAllowed(makeCtx({ trustLevel: 'trusted' }), req)).toThrow(SpawnPermissionError)
+  })
+
+  it('allows sensitive env override for benevolent caller', () => {
+    const req: SpawnRequest = { ...baseReq, env: { ANTHROPIC_API_KEY: 'sk-xxx' } }
+    expect(() => assertSpawnAllowed(makeCtx({ trustLevel: 'benevolent' }), req)).not.toThrow()
+  })
+
+  it('denies untrusted caller even at base level (via bypass)', () => {
+    const req: SpawnRequest = { ...baseReq, permissionMode: 'bypassPermissions' }
+    const levels: TrustLevel[] = ['untrusted', 'trusted']
+    for (const lvl of levels) {
+      expect(() => assertSpawnAllowed(makeCtx({ trustLevel: lvl }), req)).toThrow(SpawnPermissionError)
+    }
+  })
+})
+
+describe('mapProjectTrust', () => {
+  it('maps benevolent -> benevolent', () => {
+    expect(mapProjectTrust('benevolent')).toBe('benevolent')
+  })
+
+  it('maps default -> trusted', () => {
+    expect(mapProjectTrust('default')).toBe('trusted')
+  })
+
+  it('maps open -> trusted', () => {
+    expect(mapProjectTrust('open')).toBe('trusted')
+  })
+
+  it('maps undefined -> trusted', () => {
+    expect(mapProjectTrust(undefined)).toBe('trusted')
+  })
+})

--- a/src/shared/spawn-permissions.ts
+++ b/src/shared/spawn-permissions.ts
@@ -1,0 +1,90 @@
+/**
+ * Unified spawn permission gate.
+ *
+ * Single source of truth for the cross-transport (HTTP / WS / MCP) checks
+ * that every spawn path must agree on. Callers translate their native
+ * auth/trust signals into a `SpawnCallerContext` and let this module decide.
+ *
+ * Base rule: spawn permission is always required.
+ * MCP rule: the MCP caller's own project must be `benevolent`.
+ * Field rules:
+ *   - `permissionMode: 'bypassPermissions'` requires `benevolent` trust
+ *   - Overrides of sensitive env keys require `benevolent` trust
+ */
+
+import type { SpawnRequest } from './spawn-schema'
+
+export type TrustLevel = 'untrusted' | 'trusted' | 'benevolent'
+
+export type SpawnCallerKind = 'http' | 'ws' | 'mcp'
+
+export type SpawnCallerContext = {
+  kind: SpawnCallerKind
+  hasSpawnPermission: boolean
+  trustLevel: TrustLevel
+  /** Caller's own cwd, for MCP cross-project trust checks. null for dashboard callers. */
+  cwd: string | null
+}
+
+/** Thrown when spawn is denied. Callers map to HTTP 403 / WS error reply. */
+export class SpawnPermissionError extends Error {
+  code = 'spawn_forbidden'
+  field: string | undefined
+  required: TrustLevel | 'spawn_permission'
+  constructor(message: string, field?: string, required: TrustLevel | 'spawn_permission' = 'spawn_permission') {
+    super(message)
+    this.name = 'SpawnPermissionError'
+    this.field = field
+    this.required = required
+  }
+}
+
+export const SENSITIVE_ENV_KEYS: ReadonlySet<string> = new Set([
+  'HOME',
+  'PATH',
+  'USER',
+  'SHELL',
+  'LOGNAME',
+  'SUDO_USER',
+  'ANTHROPIC_API_KEY',
+])
+
+/**
+ * Unified spawn gate. Throws SpawnPermissionError on deny.
+ */
+export function assertSpawnAllowed(ctx: SpawnCallerContext, req: SpawnRequest): void {
+  if (!ctx.hasSpawnPermission) {
+    throw new SpawnPermissionError('Spawn permission required', undefined, 'spawn_permission')
+  }
+  if (ctx.kind === 'mcp' && ctx.trustLevel !== 'benevolent') {
+    throw new SpawnPermissionError('Spawn via MCP requires benevolent trust on caller project', undefined, 'benevolent')
+  }
+  if (req.permissionMode === 'bypassPermissions' && ctx.trustLevel !== 'benevolent') {
+    throw new SpawnPermissionError('bypassPermissions mode requires benevolent trust', 'permissionMode', 'benevolent')
+  }
+  if (req.env) {
+    for (const key of Object.keys(req.env)) {
+      if (SENSITIVE_ENV_KEYS.has(key) && ctx.trustLevel !== 'benevolent') {
+        throw new SpawnPermissionError(
+          `Override of sensitive env "${key}" requires benevolent trust`,
+          'env',
+          'benevolent',
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Map the wire-level `ProjectSettings.trustLevel` ('default' | 'open' | 'benevolent' | undefined)
+ * to the internal {@link TrustLevel} used by {@link assertSpawnAllowed}.
+ *
+ * - `benevolent` stays `benevolent`
+ * - everything else collapses to `trusted` (dashboard default)
+ * - `untrusted` is reserved for callers that want to deny by default
+ *   (pass `'untrusted'` explicitly, e.g. guest/share sessions)
+ */
+export function mapProjectTrust(trust: 'default' | 'open' | 'benevolent' | undefined): TrustLevel {
+  if (trust === 'benevolent') return 'benevolent'
+  return 'trusted'
+}

--- a/src/shared/spawn-prompt.test.ts
+++ b/src/shared/spawn-prompt.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTO_COMMIT_INSTRUCTIONS,
+  buildTaskPrompt,
+  composeSpawnPrompt,
+  type TaskMeta,
+  WORKTREE_MERGEBACK_INSTRUCTIONS,
+} from './spawn-prompt'
+
+const baseTask: TaskMeta = {
+  slug: 'my-task',
+  title: 'Do the thing',
+  status: 'open',
+  priority: 'high',
+  tags: ['alpha', 'beta'],
+  bodyPreview: 'short preview',
+  body: 'the full task body',
+}
+
+describe('composeSpawnPrompt', () => {
+  it('returns base prompt unchanged when no options', () => {
+    expect(composeSpawnPrompt('hello', {})).toBe('hello')
+  })
+
+  it('appends auto-commit instructions when autoCommit=true', () => {
+    const out = composeSpawnPrompt('hello', { autoCommit: true })
+    expect(out).toBe(`hello${AUTO_COMMIT_INSTRUCTIONS}`)
+  })
+
+  it('appends worktree merge-back instructions when worktreeMergeBack=true', () => {
+    const out = composeSpawnPrompt('hello', { worktreeMergeBack: true })
+    expect(out).toBe(`hello${WORKTREE_MERGEBACK_INSTRUCTIONS}`)
+  })
+
+  it('appends both suffixes when both flags are true', () => {
+    const out = composeSpawnPrompt('hello', { autoCommit: true, worktreeMergeBack: true })
+    expect(out).toBe(`hello${AUTO_COMMIT_INSTRUCTIONS}${WORKTREE_MERGEBACK_INSTRUCTIONS}`)
+  })
+
+  it('wraps in <project-task> when taskWrapper is provided', () => {
+    const out = composeSpawnPrompt('', { taskWrapper: baseTask })
+    expect(out).toContain('<project-task ')
+    expect(out).toContain('id="my-task"')
+    expect(out).toContain('title="Do the thing"')
+    expect(out).toContain('priority="high"')
+    expect(out).toContain('status="open"')
+    expect(out).toContain('tags="alpha,beta"')
+    expect(out).toContain('the full task body')
+    expect(out).toContain('</project-task>')
+  })
+
+  it('wraps suffixes inside <project-task> when taskWrapper + lifecycle flags', () => {
+    const out = composeSpawnPrompt('', {
+      taskWrapper: baseTask,
+      autoCommit: true,
+      worktreeMergeBack: true,
+    })
+    expect(out).toContain('<project-task ')
+    expect(out).toContain(AUTO_COMMIT_INSTRUCTIONS.trim())
+    expect(out).toContain(WORKTREE_MERGEBACK_INSTRUCTIONS.trim())
+    // suffixes must land before closing tag
+    expect(out.indexOf('git rebase main')).toBeLessThan(out.indexOf('</project-task>'))
+  })
+
+  it('uses custom base prompt as task body when provided', () => {
+    const out = composeSpawnPrompt('custom override content', { taskWrapper: baseTask })
+    expect(out).toContain('custom override content')
+    expect(out).not.toContain('the full task body')
+  })
+})
+
+describe('buildTaskPrompt', () => {
+  it('escapes quotes in title attribute', () => {
+    const task: TaskMeta = { ...baseTask, title: 'Fix "quoted" bug' }
+    const out = buildTaskPrompt(task)
+    expect(out).toContain('title="Fix &quot;quoted&quot; bug"')
+  })
+
+  it('omits priority attr when medium (default)', () => {
+    const task: TaskMeta = { ...baseTask, priority: 'medium' }
+    const out = buildTaskPrompt(task)
+    expect(out).not.toContain('priority=')
+  })
+
+  it('omits priority attr when missing', () => {
+    const task: TaskMeta = { ...baseTask, priority: undefined }
+    const out = buildTaskPrompt(task)
+    expect(out).not.toContain('priority=')
+  })
+
+  it('omits tags attr when tag array is empty', () => {
+    const task: TaskMeta = { ...baseTask, tags: [] }
+    const out = buildTaskPrompt(task)
+    expect(out).not.toContain('tags=')
+  })
+
+  it('appends extra instructions before closing tag', () => {
+    const out = buildTaskPrompt(baseTask, '\n\nExtra!')
+    expect(out).toContain('Extra!')
+    expect(out.indexOf('Extra!')).toBeLessThan(out.indexOf('</project-task>'))
+  })
+
+  it('uses task.body when basePrompt is absent', () => {
+    const out = buildTaskPrompt(baseTask)
+    expect(out).toContain('the full task body')
+  })
+
+  it('falls back to bodyPreview when body is absent', () => {
+    const task: TaskMeta = { ...baseTask, body: undefined }
+    const out = buildTaskPrompt(task)
+    expect(out).toContain('short preview')
+  })
+
+  it('falls back to title when body and bodyPreview are absent', () => {
+    const task: TaskMeta = { ...baseTask, body: undefined, bodyPreview: undefined }
+    const out = buildTaskPrompt(task)
+    expect(out).toContain('Do the thing')
+  })
+
+  it('always includes set-status instructions with the slug', () => {
+    const out = buildTaskPrompt(baseTask)
+    expect(out).toContain('mcp__rclaude__project_set_status')
+    expect(out).toContain('id="my-task"')
+  })
+})

--- a/src/shared/spawn-prompt.ts
+++ b/src/shared/spawn-prompt.ts
@@ -1,0 +1,68 @@
+/**
+ * Canonical prompt assembly for spawn requests.
+ *
+ * Used by:
+ * - Dashboard RunTaskDialog (web/src/components/project-board.tsx)
+ * - web/src/lib/task-scoring.ts (re-exports buildTaskPrompt)
+ * - Wrapper /workon slash command (when applicable)
+ *
+ * Single source of truth for:
+ * - AUTO_COMMIT_INSTRUCTIONS (auto-commit suffix)
+ * - WORKTREE_MERGEBACK_INSTRUCTIONS (worktree merge-back suffix)
+ * - <project-task> wrapper format
+ */
+
+export type TaskMeta = {
+  slug: string
+  title: string
+  status: string
+  priority?: string
+  tags: string[]
+  bodyPreview?: string
+  body?: string
+}
+
+export const AUTO_COMMIT_INSTRUCTIONS = '\n\nWhen you are done, commit all changes with a descriptive commit message.'
+
+export const WORKTREE_MERGEBACK_INSTRUCTIONS =
+  '\n\nIMPORTANT - WORKTREE MERGE-BACK:\nYou are working in a git worktree (isolated branch). Before finishing:\n1. Commit all changes\n2. Merge back to main: run `git rebase main && git fetch . HEAD:main`\n3. If rebase conflicts occur, resolve them and run `git rebase --continue`, then `git fetch . HEAD:main`\n4. Verify: `git log --oneline main -5`\nThis merges your work back to main so it is not stranded on a dead branch.'
+
+export type PromptOptions = {
+  autoCommit?: boolean
+  worktreeMergeBack?: boolean
+  taskWrapper?: TaskMeta
+}
+
+/**
+ * Wrap a base prompt with optional task wrapper and lifecycle suffixes.
+ * Order: taskWrapper(base + suffixes) OR base + suffixes.
+ */
+export function composeSpawnPrompt(basePrompt: string, opts: PromptOptions = {}): string {
+  const suffixes =
+    (opts.autoCommit ? AUTO_COMMIT_INSTRUCTIONS : '') + (opts.worktreeMergeBack ? WORKTREE_MERGEBACK_INSTRUCTIONS : '')
+  if (opts.taskWrapper) {
+    return buildTaskPrompt(opts.taskWrapper, suffixes || undefined, basePrompt || undefined)
+  }
+  return basePrompt + suffixes
+}
+
+/**
+ * Build a <project-task> wrapped prompt. Canonical source for both the
+ * dashboard task runner and the /workon slash command.
+ *
+ * If `basePrompt` is provided (non-empty), it overrides the task body content.
+ */
+export function buildTaskPrompt(task: TaskMeta, extraInstructions?: string, basePrompt?: string): string {
+  const tagAttrs = [
+    `id="${task.slug}"`,
+    `title="${task.title.replace(/"/g, '&quot;')}"`,
+    task.priority && task.priority !== 'medium' ? `priority="${task.priority}"` : '',
+    `status="${task.status}"`,
+    task.tags.length ? `tags="${task.tags.join(',')}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const content = (basePrompt ?? task.body ?? task.bodyPreview ?? task.title).trim() || task.title
+  const instructions = `Set status to in-progress when you start, in-review when complete. Use mcp__rclaude__project_set_status with id="${task.slug}".`
+  return `<project-task ${tagAttrs}>\n${content}\n\n${instructions}${extraInstructions || ''}\n</project-task>`
+}

--- a/src/shared/spawn-schema.ts
+++ b/src/shared/spawn-schema.ts
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for spawn requests.
+ *
+ * Consumers:
+ * - HTTP route: src/concentrator/routes.ts (/api/spawn)
+ * - MCP tool: src/wrapper/mcp-channel.ts (spawn_session)
+ * - Dashboard: web/src/components/spawn-dialog.tsx
+ * - Dashboard: web/src/components/project-board.tsx (RunTaskDialog)
+ */
+
+import { z } from 'zod'
+
+export const DEFAULT_SENTINEL = '__default__'
+
+export const MODEL_OPTIONS = [
+  { value: DEFAULT_SENTINEL, label: 'Default', info: 'Use project / global default' },
+  { value: 'opus', label: 'Opus (latest)', info: 'Most capable, best for complex reasoning' },
+  { value: 'claude-opus-4-7', label: 'Opus 4.7', info: 'Opus 4.7 pinned (1M context)' },
+  { value: 'claude-opus-4-6', label: 'Opus 4.6', info: 'Opus 4.6 pinned (1M context)' },
+  { value: 'sonnet', label: 'Sonnet (latest)', info: 'Balanced speed and capability' },
+  { value: 'haiku', label: 'Haiku (latest)', info: 'Fastest, lowest cost' },
+] as const
+
+export const EFFORT_OPTIONS = [
+  { value: DEFAULT_SENTINEL, label: 'Default', info: 'Use project / global default' },
+  { value: 'low', label: 'Low', info: 'Minimal thinking budget' },
+  { value: 'medium', label: 'Medium', info: 'Moderate thinking' },
+  { value: 'high', label: 'High', info: 'Deep thinking (slower)' },
+  { value: 'xhigh', label: 'XHigh', info: 'Extended deep thinking' },
+  { value: 'max', label: 'Max', info: 'Maximum thinking budget' },
+] as const
+
+export const PERMISSION_MODE_OPTIONS = [
+  { value: DEFAULT_SENTINEL, label: 'Default', info: 'CC default prompting behaviour' },
+  { value: 'plan', label: 'Plan', info: 'Plan-first mode' },
+  { value: 'acceptEdits', label: 'Accept Edits', info: 'Auto-accept file edits' },
+  { value: 'auto', label: 'Auto', info: 'Auto-approve most tools' },
+  { value: 'bypassPermissions', label: 'Bypass', info: 'Skip permission prompts (dangerous)' },
+] as const
+
+// Keep TIMEOUT_OPTIONS simple; used only by RunTaskDialog today
+export const TIMEOUT_OPTIONS = [
+  { value: '5', label: '5 min' },
+  { value: '10', label: '10 min' },
+  { value: '15', label: '15 min' },
+  { value: '30', label: '30 min' },
+  { value: '0', label: 'No timeout' },
+] as const
+
+export const modelEnum = z.enum(['opus', 'sonnet', 'haiku', 'claude-opus-4-7', 'claude-opus-4-6'])
+export const effortEnum = z.enum(['low', 'medium', 'high', 'xhigh', 'max'])
+export const permissionModeEnum = z.enum(['plan', 'acceptEdits', 'auto', 'bypassPermissions'])
+export const spawnModeEnum = z.enum(['fresh', 'resume'])
+
+export const spawnRequestSchema = z.object({
+  cwd: z.string().describe('Working directory (absolute path, ~ supported)'),
+  mkdir: z.boolean().optional().describe('Create cwd if it does not exist'),
+  mode: spawnModeEnum.optional().describe('"fresh" (default) or "resume" to resume a specific CC session'),
+  resumeId: z.string().optional().describe('Claude Code session ID to resume when mode=resume'),
+  headless: z
+    .boolean()
+    .optional()
+    .describe('stream-json mode. Default: true for ad-hoc, otherwise project/global default'),
+  bare: z.boolean().optional().describe('Launch without injecting hooks'),
+  repl: z.boolean().optional().describe('Launch CC in REPL mode'),
+  name: z.string().optional().describe('Display label in sidebar'),
+  model: modelEnum.optional().describe('Model preset or pinned version'),
+  effort: effortEnum.optional().describe('Thinking effort budget'),
+  permissionMode: permissionModeEnum.optional().describe('CC permission prompting mode'),
+  autocompactPct: z.number().min(0).max(100).optional().describe('Auto-compact threshold (%)'),
+  maxBudgetUsd: z.number().positive().optional().describe('Max spend in USD before auto-stop'),
+  worktree: z.string().optional().describe('Branch name - creates isolated git worktree'),
+  env: z.record(z.string(), z.string()).optional().describe('Env var overrides'),
+  prompt: z.string().optional().describe('Initial prompt (headless only)'),
+  adHoc: z.boolean().optional().describe('Mark as ad-hoc task runner session'),
+  adHocTaskId: z.string().optional().describe('Project task slug when adHoc=true'),
+  leaveRunning: z.boolean().optional().describe('Keep session running after prompt completes'),
+  jobId: z.string().uuid().optional().describe('Caller-supplied job id for progress correlation'),
+})
+export type SpawnRequest = z.infer<typeof spawnRequestSchema>

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -975,6 +975,11 @@ async function main() {
         pendingSpawnDiagnostics.delete(result.jobId)
         resolver(result)
       },
+      onLaunchJobEvent(event) {
+        const jobId = typeof event.jobId === 'string' ? event.jobId : undefined
+        if (!jobId) return
+        launchJobListeners.get(jobId)?.(event)
+      },
       onChannelConfigureResult(result) {
         pendingConfigureResult?.(result)
       },
@@ -1352,29 +1357,51 @@ async function main() {
         } as unknown as WrapperMessage)
       })
     },
-    async onSpawnSession({ cwd, mode, resumeId, mkdir, headless: spawnHeadless }) {
+    async onSpawnSession({ cwd, mode, resumeId, mkdir, headless: spawnHeadless, jobId, onProgress }) {
       if (!ctx.wsClient?.isConnected()) return { ok: false, error: 'Not connected to concentrator' }
 
-      // Step 1: Send spawn request via WS, get immediate ack with wrapperId
-      const spawnResult = await new Promise<{ ok: boolean; error?: string; wrapperId?: string }>(resolve => {
-        const timeout = setTimeout(() => resolve({ ok: false, error: 'Timeout' }), 15000)
-        pendingSpawnResult = result => {
-          clearTimeout(timeout)
-          pendingSpawnResult = null
-          resolve(result)
-        }
-        ctx.wsClient?.send({
-          type: 'channel_spawn',
-          cwd,
-          mode,
-          resumeId,
-          mkdir,
-          headless: spawnHeadless,
-        } as unknown as WrapperMessage)
-      })
+      // If the MCP caller wants progress, subscribe to the job BEFORE sending
+      // channel_spawn so the first launch_progress events are not missed.
+      if (jobId && onProgress) {
+        launchJobListeners.set(jobId, onProgress)
+        ctx.wsClient?.send({ type: 'subscribe_job', jobId } as unknown as WrapperMessage)
+      }
 
-      if (!spawnResult.ok) return spawnResult
+      // Step 1: Send spawn request via WS, get immediate ack with wrapperId
+      const spawnResult = await new Promise<{ ok: boolean; error?: string; wrapperId?: string; jobId?: string }>(
+        resolve => {
+          const timeout = setTimeout(() => resolve({ ok: false, error: 'Timeout' }), 15000)
+          pendingSpawnResult = result => {
+            clearTimeout(timeout)
+            pendingSpawnResult = null
+            resolve(result)
+          }
+          ctx.wsClient?.send({
+            type: 'channel_spawn',
+            cwd,
+            mode,
+            resumeId,
+            mkdir,
+            headless: spawnHeadless,
+            jobId,
+          } as unknown as WrapperMessage)
+        },
+      )
+
+      if (!spawnResult.ok) {
+        if (jobId) {
+          launchJobListeners.delete(jobId)
+          ctx.wsClient?.send({ type: 'unsubscribe_job', jobId } as unknown as WrapperMessage)
+        }
+        return spawnResult
+      }
       diag('channel', `spawn_session: ${cwd} mode=${mode || 'default'} wrapperId=${spawnResult.wrapperId?.slice(0, 8)}`)
+
+      const cleanupJob = () => {
+        if (!jobId) return
+        launchJobListeners.delete(jobId)
+        ctx.wsClient?.send({ type: 'unsubscribe_job', jobId } as unknown as WrapperMessage)
+      }
 
       // Step 2: Await rendezvous (concentrator sends spawn_ready/spawn_timeout when session connects)
       if (spawnResult.wrapperId) {
@@ -1398,14 +1425,17 @@ async function main() {
           })
           const session = result.session as Record<string, unknown> | undefined
           diag('channel', `spawn_session: rendezvous resolved session=${(result.sessionId as string)?.slice(0, 8)}`)
-          return { ok: true, wrapperId: spawnResult.wrapperId, session }
+          cleanupJob()
+          return { ok: true, wrapperId: spawnResult.wrapperId, jobId, session }
         } catch (err) {
           diag('channel', `spawn_session: rendezvous failed: ${err instanceof Error ? err.message : err}`)
-          return { ok: true, wrapperId: spawnResult.wrapperId, timedOut: true }
+          cleanupJob()
+          return { ok: true, wrapperId: spawnResult.wrapperId, jobId, timedOut: true }
         }
       }
 
-      return { ok: true, wrapperId: spawnResult.wrapperId }
+      cleanupJob()
+      return { ok: true, wrapperId: spawnResult.wrapperId, jobId }
     },
     async onGetSpawnDiagnostics(jobId) {
       if (!ctx.wsClient?.isConnected()) return { ok: false, error: 'Not connected to concentrator' }
@@ -1513,6 +1543,10 @@ async function main() {
     string,
     (result: { ok: boolean; jobId?: string; error?: string; diagnostics?: Record<string, unknown> }) => void
   >()
+  // jobId -> listener for launch_progress / launch_log / job_complete /
+  // job_failed events. Populated when an MCP spawn_session caller passes a
+  // progressToken; cleared when the spawn resolves (either side of timeout).
+  const launchJobListeners = new Map<string, (event: Record<string, unknown>) => void>()
   let pendingConfigureResult: ((result: { ok: boolean; error?: string }) => void) | null = null
   let pendingRenameResult: ((result: { ok: boolean; error?: string }) => void) | null = null
   const pendingRendezvous = new Map<

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -968,6 +968,13 @@ async function main() {
       onChannelSpawnResult(result) {
         pendingSpawnResult?.(result)
       },
+      onSpawnDiagnosticsResult(result) {
+        if (!result.jobId) return
+        const resolver = pendingSpawnDiagnostics.get(result.jobId)
+        if (!resolver) return
+        pendingSpawnDiagnostics.delete(result.jobId)
+        resolver(result)
+      },
       onChannelConfigureResult(result) {
         pendingConfigureResult?.(result)
       },
@@ -1400,6 +1407,23 @@ async function main() {
 
       return { ok: true, wrapperId: spawnResult.wrapperId }
     },
+    async onGetSpawnDiagnostics(jobId) {
+      if (!ctx.wsClient?.isConnected()) return { ok: false, error: 'Not connected to concentrator' }
+      return new Promise(resolve => {
+        const timeout = setTimeout(() => {
+          pendingSpawnDiagnostics.delete(jobId)
+          resolve({ ok: false, error: 'Timeout waiting for diagnostics' })
+        }, 10_000)
+        pendingSpawnDiagnostics.set(jobId, result => {
+          clearTimeout(timeout)
+          resolve(result)
+        })
+        ctx.wsClient?.send({
+          type: 'get_spawn_diagnostics',
+          jobId,
+        } as unknown as WrapperMessage)
+      })
+    },
     async onRestartSession(sessionId) {
       if (!ctx.wsClient?.isConnected()) return { ok: false, error: 'Not connected to concentrator' }
       return new Promise(resolve => {
@@ -1483,6 +1507,12 @@ async function main() {
     | ((result: { ok: boolean; error?: string; name?: string; selfRestart?: boolean; alreadyEnded?: boolean }) => void)
     | null = null
   let pendingSpawnResult: ((result: { ok: boolean; error?: string; wrapperId?: string }) => void) | null = null
+  // Keyed by jobId so concurrent get_spawn_diagnostics calls don't trample each
+  // other. Concentrator replies include the jobId so we can route back.
+  const pendingSpawnDiagnostics = new Map<
+    string,
+    (result: { ok: boolean; jobId?: string; error?: string; diagnostics?: Record<string, unknown> }) => void
+  >()
   let pendingConfigureResult: ((result: { ok: boolean; error?: string }) => void) | null = null
   let pendingRenameResult: ((result: { ok: boolean; error?: string }) => void) | null = null
   const pendingRendezvous = new Map<

--- a/src/wrapper/mcp-channel.ts
+++ b/src/wrapper/mcp-channel.ts
@@ -18,9 +18,11 @@ import { join, resolve as resolvePath } from 'node:path'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
 import type { DialogLayout, DialogResult } from '../shared/dialog-schema'
 import { dialogToolInputSchema, validateDialogLayout } from '../shared/dialog-schema'
 import { isPathWithinCwd } from '../shared/path-guard'
+import { spawnRequestSchema } from '../shared/spawn-schema'
 import { DEFAULT_VISIBLE_STATUSES, TASK_STATUSES, type TaskStatus } from '../shared/task-statuses'
 import { checkForUpdate, formatUpdateResult } from '../shared/update-check'
 import { debug } from './debug'
@@ -314,6 +316,29 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
   )
   const server = mcpServer.server // low-level access for custom handlers
 
+  // spawn_session input schema: shared spawn fields + MCP-specific (action, session_id, resume_id alias).
+  // cwd is only required for action=spawn; make it optional at schema level and validate in handler.
+  const spawnToolSchema = spawnRequestSchema
+    .extend({
+      action: z
+        .enum(['spawn', 'revive', 'restart'])
+        .optional()
+        .describe(
+          'Action to perform. "spawn" = new session at cwd, "revive" = bring back an ended session, "restart" = terminate + auto-revive. Default: spawn.',
+        ),
+      session_id: z
+        .string()
+        .optional()
+        .describe('Target session ID from list_sessions. Required for revive and restart actions.'),
+      resume_id: z.string().optional().describe('Claude Code session ID to resume (alias for resumeId).'),
+    })
+    .partial({ cwd: true })
+  const spawnToolInputSchema = z.toJSONSchema(spawnToolSchema) as {
+    type: 'object'
+    properties?: Record<string, unknown>
+    required?: string[]
+  }
+
   // Register MCP tools
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
@@ -412,44 +437,7 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
         name: 'spawn_session',
         description:
           'Unified session lifecycle tool. Spawn new sessions, revive ended ones, or restart active sessions (terminate + auto-revive). Requires benevolent trust level. Sessions boot in tmux on the host - takes 10-30 seconds. Use list_sessions to poll for status.\n\nActions:\n- spawn (default): Start a new session at a directory\n- revive: Bring back an ended/inactive session\n- restart: Terminate an active session and automatically revive it. For self-restart, the MCP response may not arrive (your process dies and reboots).',
-        inputSchema: {
-          type: 'object' as const,
-          properties: {
-            action: {
-              type: 'string',
-              enum: ['spawn', 'revive', 'restart'],
-              description:
-                'Action to perform. "spawn" = new session at cwd, "revive" = bring back an ended session, "restart" = terminate + auto-revive. Default: spawn.',
-            },
-            session_id: {
-              type: 'string',
-              description: 'Target session ID from list_sessions. Required for revive and restart actions.',
-            },
-            cwd: {
-              type: 'string',
-              description: 'Working directory for new session (absolute path, ~ supported). Required for spawn action.',
-            },
-            mode: {
-              type: 'string',
-              enum: ['fresh', 'resume'],
-              description:
-                'Spawn mode (only for action=spawn): "fresh" = new session, "resume" = resume specific session by ID. Default: fresh.',
-            },
-            resume_id: {
-              type: 'string',
-              description: 'Claude Code session ID to resume (required when mode is "resume")',
-            },
-            mkdir: {
-              type: 'boolean',
-              description: 'Create the directory if it does not exist (default: false, only for action=spawn)',
-            },
-            headless: {
-              type: 'boolean',
-              description:
-                'Spawn in headless mode (stream-json, no terminal). Default: true. Set false for interactive PTY mode.',
-            },
-          },
-        },
+        inputSchema: spawnToolInputSchema,
       },
       {
         name: 'configure_session',

--- a/src/wrapper/mcp-channel.ts
+++ b/src/wrapper/mcp-channel.ts
@@ -98,6 +98,9 @@ export interface McpChannelCallbacks {
     mkdir?: boolean
     headless?: boolean
   }) => Promise<{ ok: boolean; error?: string; wrapperId?: string }>
+  onGetSpawnDiagnostics?: (
+    jobId: string,
+  ) => Promise<{ ok: boolean; error?: string; diagnostics?: Record<string, unknown> }>
   onConfigureSession?: (params: {
     sessionId: string
     label?: string
@@ -438,6 +441,21 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
         description:
           'Unified session lifecycle tool. Spawn new sessions, revive ended ones, or restart active sessions (terminate + auto-revive). Requires benevolent trust level. Sessions boot in tmux on the host - takes 10-30 seconds. Use list_sessions to poll for status.\n\nActions:\n- spawn (default): Start a new session at a directory\n- revive: Bring back an ended/inactive session\n- restart: Terminate an active session and automatically revive it. For self-restart, the MCP response may not arrive (your process dies and reboots).',
         inputSchema: spawnToolInputSchema,
+      },
+      {
+        name: 'get_spawn_diagnostics',
+        description:
+          'Fetch a diagnostic snapshot for a spawn job by jobId. Returns the resolved config, the full event timeline (job_created, spawn_sent, agent_acked, wrapper_booted, session_connected, job_complete/job_failed), and any error. Use this to debug spawn failures after spawn_session returned a wrapperId but the session never connected. Jobs expire ~5 minutes after creation. The jobId comes from the spawn_session response (pass `jobId` to spawn_session to track it).',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            job_id: {
+              type: 'string',
+              description: 'The jobId returned by a prior spawn_session call (or any spawn dispatch).',
+            },
+          },
+          required: ['job_id'],
+        },
       },
       {
         name: 'configure_session',
@@ -916,6 +934,38 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
                 text: result.timedOut
                   ? `Session spawn sent to ${cwd} (${modeDesc}) but session did not connect within 2 minutes. It may still be booting - use list_sessions to check.`
                   : `Session spawning at ${cwd} (${modeDesc}). Use list_sessions to check when ready.`,
+              },
+            ],
+          }
+        }
+        case 'get_spawn_diagnostics': {
+          const jobId = typeof params.job_id === 'string' ? params.job_id.trim() : ''
+          if (!jobId) {
+            return {
+              content: [{ type: 'text', text: 'Error: job_id is required' }],
+              isError: true,
+            }
+          }
+          if (!callbacks.onGetSpawnDiagnostics) {
+            return {
+              content: [{ type: 'text', text: 'Error: diagnostics channel not available' }],
+              isError: true,
+            }
+          }
+          const result = await callbacks.onGetSpawnDiagnostics(jobId)
+          if (!result.ok) {
+            debug(`[channel] get_spawn_diagnostics(${jobId.slice(0, 8)}) failed: ${result.error}`)
+            return {
+              content: [{ type: 'text', text: result.error || 'Diagnostics unavailable' }],
+              isError: true,
+            }
+          }
+          debug(`[channel] get_spawn_diagnostics(${jobId.slice(0, 8)}): ok`)
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(result.diagnostics, null, 2),
               },
             ],
           }

--- a/src/wrapper/mcp-channel.ts
+++ b/src/wrapper/mcp-channel.ts
@@ -97,7 +97,16 @@ export interface McpChannelCallbacks {
     resumeId?: string
     mkdir?: boolean
     headless?: boolean
-  }) => Promise<{ ok: boolean; error?: string; wrapperId?: string }>
+    /**
+     * If set, the callback should create a tracked job with this ID and call
+     * onProgress on each launch_progress event so the MCP tool can forward
+     * them as notifications/progress. Implementation detail: the wrapper
+     * subscribes on this WS before dispatching channel_spawn so no events are
+     * missed.
+     */
+    jobId?: string
+    onProgress?: (event: Record<string, unknown>) => void
+  }) => Promise<{ ok: boolean; error?: string; wrapperId?: string; jobId?: string }>
   onGetSpawnDiagnostics?: (
     jobId: string,
   ) => Promise<{ ok: boolean; error?: string; diagnostics?: Record<string, unknown> }>
@@ -556,10 +565,14 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
     ],
   }))
 
-  server.setRequestHandler(CallToolRequestSchema, async request => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     try {
       const { name, arguments: args } = request.params
       const params = (args || {}) as Record<string, string>
+      // MCP clients opt into streaming progress by supplying a progressToken
+      // in the request _meta. If present, we push notifications/progress
+      // during long-running tools (currently spawn_session).
+      const progressToken = (request.params._meta as { progressToken?: string | number } | undefined)?.progressToken
 
       switch (name) {
         case 'notify': {
@@ -898,8 +911,76 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
           }
           const mkdir = String(params.mkdir) === 'true'
           const spawnHeadless = params.headless !== undefined ? String(params.headless) !== 'false' : true
-          const result = (await callbacks.onSpawnSession?.({ cwd, mode, resumeId, mkdir, headless: spawnHeadless })) as
-            | { ok: boolean; error?: string; wrapperId?: string; session?: Record<string, unknown>; timedOut?: boolean }
+
+          // Wire progress streaming if the caller supplied a progressToken.
+          // We build a local jobId and a pump that forwards launch_progress
+          // events as notifications/progress with a rough phase -> percent
+          // mapping so MCP clients can render a progress bar instead of
+          // staring at silence while tmux spins up.
+          let jobId: string | undefined
+          let onProgress: ((event: Record<string, unknown>) => void) | undefined
+          if (progressToken !== undefined) {
+            jobId = randomUUID()
+            const stepToPercent: Record<string, number> = {
+              job_created: 5,
+              spawn_sent: 15,
+              agent_acked: 30,
+              wrapper_booted: 60,
+              session_connected: 95,
+              completed: 100,
+            }
+            onProgress = event => {
+              const type = event.type as string
+              const step = typeof event.step === 'string' ? event.step : undefined
+              const status = typeof event.status === 'string' ? event.status : undefined
+              const detail = typeof event.detail === 'string' ? event.detail : undefined
+              let progress = 0
+              let message = step || type
+              if (type === 'job_complete') {
+                progress = 100
+                message = 'Session connected'
+              } else if (type === 'job_failed') {
+                progress = 100
+                message = `Failed: ${typeof event.error === 'string' ? event.error : 'unknown'}`
+              } else if (step && step in stepToPercent) {
+                progress = stepToPercent[step]
+                if (detail) message = `${step}: ${detail}`
+                else message = step
+                if (status === 'error') message = `Failed at ${step}`
+              }
+              extra
+                .sendNotification?.({
+                  method: 'notifications/progress',
+                  params: {
+                    progressToken,
+                    progress,
+                    total: 100,
+                    message,
+                  },
+                })
+                .catch(() => {
+                  // Notifications are best-effort -- swallow to avoid killing the spawn if the transport hiccups
+                })
+            }
+          }
+
+          const result = (await callbacks.onSpawnSession?.({
+            cwd,
+            mode,
+            resumeId,
+            mkdir,
+            headless: spawnHeadless,
+            jobId,
+            onProgress,
+          })) as
+            | {
+                ok: boolean
+                error?: string
+                wrapperId?: string
+                jobId?: string
+                session?: Record<string, unknown>
+                timedOut?: boolean
+              }
             | undefined
           if (!result?.ok) {
             debug(`[channel] spawn_session failed: ${result?.error}`)
@@ -908,6 +989,7 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
           const modeDesc = mode === 'resume' ? `resuming ${resumeId}` : 'fresh start'
           debug(`[channel] spawn_session: ${cwd} (${modeDesc}) session=${result.session ? 'ready' : 'pending'}`)
 
+          const responseJobId = result.jobId ?? jobId
           if (result.session) {
             return {
               content: [
@@ -918,6 +1000,8 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
                       status: 'ready',
                       message: `Session spawned and connected at ${cwd} (${modeDesc})`,
                       session: result.session,
+                      jobId: responseJobId,
+                      wrapperId: result.wrapperId,
                     },
                     null,
                     2,
@@ -932,8 +1016,8 @@ export function initMcpChannel(cb: McpChannelCallbacks): void {
               {
                 type: 'text',
                 text: result.timedOut
-                  ? `Session spawn sent to ${cwd} (${modeDesc}) but session did not connect within 2 minutes. It may still be booting - use list_sessions to check.`
-                  : `Session spawning at ${cwd} (${modeDesc}). Use list_sessions to check when ready.`,
+                  ? `Session spawn sent to ${cwd} (${modeDesc}) but session did not connect within 2 minutes. It may still be booting - use list_sessions to check.${responseJobId ? ` jobId=${responseJobId}` : ''}`
+                  : `Session spawning at ${cwd} (${modeDesc}). Use list_sessions to check when ready.${responseJobId ? ` jobId=${responseJobId}` : ''}`,
               },
             ],
           }

--- a/src/wrapper/ws-client.ts
+++ b/src/wrapper/ws-client.ts
@@ -74,6 +74,12 @@ export interface WsClientOptions {
     alreadyEnded?: boolean
   }) => void
   onChannelSpawnResult?: (result: { ok: boolean; error?: string; wrapperId?: string }) => void
+  onSpawnDiagnosticsResult?: (result: {
+    ok: boolean
+    jobId?: string
+    error?: string
+    diagnostics?: Record<string, unknown>
+  }) => void
   onChannelConfigureResult?: (result: { ok: boolean; error?: string }) => void
   onChannelRenameResult?: (result: { ok: boolean; error?: string }) => void
   onAskAnswer?: (
@@ -155,6 +161,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
     onChannelReviveResult,
     onChannelRestartResult,
     onChannelSpawnResult,
+    onSpawnDiagnosticsResult,
     onChannelConfigureResult,
     onChannelRenameResult,
     onAskAnswer,
@@ -386,6 +393,17 @@ export function createWsClient(options: WsClientOptions): WsClient {
               }
               if (msgType === 'channel_spawn_result') {
                 onChannelSpawnResult?.(message as unknown as { ok: boolean; error?: string; wrapperId?: string })
+                break
+              }
+              if (msgType === 'spawn_diagnostics_result') {
+                onSpawnDiagnosticsResult?.(
+                  message as unknown as {
+                    ok: boolean
+                    jobId?: string
+                    error?: string
+                    diagnostics?: Record<string, unknown>
+                  },
+                )
                 break
               }
               if (msgType === 'channel_configure_result') {

--- a/src/wrapper/ws-client.ts
+++ b/src/wrapper/ws-client.ts
@@ -80,6 +80,12 @@ export interface WsClientOptions {
     error?: string
     diagnostics?: Record<string, unknown>
   }) => void
+  /**
+   * Launch job events for jobs this wrapper subscribed to. Fires on
+   * launch_progress / launch_log / job_complete / job_failed -- the shape
+   * matches what the concentrator forwards verbatim via forwardJobEvent.
+   */
+  onLaunchJobEvent?: (event: Record<string, unknown>) => void
   onChannelConfigureResult?: (result: { ok: boolean; error?: string }) => void
   onChannelRenameResult?: (result: { ok: boolean; error?: string }) => void
   onAskAnswer?: (
@@ -162,6 +168,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
     onChannelRestartResult,
     onChannelSpawnResult,
     onSpawnDiagnosticsResult,
+    onLaunchJobEvent,
     onChannelConfigureResult,
     onChannelRenameResult,
     onAskAnswer,
@@ -404,6 +411,15 @@ export function createWsClient(options: WsClientOptions): WsClient {
                     diagnostics?: Record<string, unknown>
                   },
                 )
+                break
+              }
+              if (
+                msgType === 'launch_progress' ||
+                msgType === 'launch_log' ||
+                msgType === 'job_complete' ||
+                msgType === 'job_failed'
+              ) {
+                onLaunchJobEvent?.(message as unknown as Record<string, unknown>)
                 break
               }
               if (msgType === 'channel_configure_result') {

--- a/web/src/components/launch-config-fields.tsx
+++ b/web/src/components/launch-config-fields.tsx
@@ -9,6 +9,8 @@
 import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS } from '@shared/spawn-schema'
 import type React from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { TileToggleRow } from '@/components/ui/tile-toggle-row'
+import { TogglePill } from '@/components/ui/toggle-pill'
 
 export type LaunchFieldKey =
   | 'model'
@@ -112,26 +114,24 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </Row>
       )}
       {show.permissionMode && (
-        <Row label="Permissions" htmlFor="lcf-permission">
-          <div className="flex-1 max-w-[220px]">
-            <Select
-              value={value.permissionMode ? value.permissionMode : DEFAULT_SENTINEL}
-              onValueChange={v => onChange({ permissionMode: v === DEFAULT_SENTINEL ? '' : v })}
-              disabled={disabled.permissionMode}
-            >
-              <SelectTrigger id="lcf-permission" size="sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {PERMISSION_MODE_OPTIONS.map(opt => (
-                  <SelectItem key={opt.value} value={opt.value} info={opt.info}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        <div className="space-y-1.5">
+          <div className="text-[10px] font-mono text-muted-foreground">Permissions</div>
+          <div className="flex flex-wrap gap-1.5">
+            {PERMISSION_MODE_OPTIONS.map(opt => {
+              const current = value.permissionMode ? value.permissionMode : DEFAULT_SENTINEL
+              return (
+                <TogglePill
+                  key={opt.value}
+                  small
+                  label={opt.label}
+                  title={opt.info}
+                  active={current === opt.value}
+                  onClick={() => onChange({ permissionMode: opt.value === DEFAULT_SENTINEL ? '' : opt.value })}
+                />
+              )
+            })}
           </div>
-        </Row>
+        </div>
       )}
       {show.autocompactPct && (
         <Row label="Auto-compact %" htmlFor="lcf-compact">
@@ -193,16 +193,13 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
       )}
       {show.worktree && (
         <div className="space-y-1.5">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={value.useWorktree ?? false}
-              onChange={e => onChange({ useWorktree: e.target.checked })}
-              disabled={disabled.worktree}
-              className="accent-amber-400"
-            />
-            <span className="text-[10px] font-mono text-muted-foreground">Use git worktree (isolated branch)</span>
-          </label>
+          <TileToggleRow
+            title="Git worktree"
+            subtitle="Isolated branch, auto-merges on completion"
+            checked={value.useWorktree ?? false}
+            onToggle={() => onChange({ useWorktree: !(value.useWorktree ?? false) })}
+            disabled={disabled.worktree}
+          />
           {value.useWorktree && (
             <input
               type="text"
@@ -216,38 +213,22 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </div>
       )}
       {show.autoCommit && (
-        <div className="space-y-0.5">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={value.autoCommit ?? false}
-              onChange={e => onChange({ autoCommit: e.target.checked })}
-              disabled={disabled.autoCommit}
-              className="accent-amber-400"
-            />
-            <span className="text-[10px] font-mono text-muted-foreground">Auto-commit on completion</span>
-          </label>
-          <div className="text-[9px] text-[#565f89] pl-5">
-            Adds a prompt instruction to commit when the task finishes
-          </div>
-        </div>
+        <TileToggleRow
+          title="Auto-commit"
+          subtitle="Adds a prompt instruction to commit when the task finishes"
+          checked={value.autoCommit ?? false}
+          onToggle={() => onChange({ autoCommit: !(value.autoCommit ?? false) })}
+          disabled={disabled.autoCommit}
+        />
       )}
       {show.leaveRunning && (
-        <div className="space-y-0.5">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={value.leaveRunning ?? false}
-              onChange={e => onChange({ leaveRunning: e.target.checked })}
-              disabled={disabled.leaveRunning}
-              className="accent-amber-400"
-            />
-            <span className="text-[10px] font-mono text-muted-foreground">Leave session running when done</span>
-          </label>
-          <div className="text-[9px] text-[#565f89] pl-5">
-            Keep session alive after the task completes for follow-up work
-          </div>
-        </div>
+        <TileToggleRow
+          title="Leave session running"
+          subtitle="Keep session alive after the task completes for follow-up work"
+          checked={value.leaveRunning ?? false}
+          onToggle={() => onChange({ leaveRunning: !(value.leaveRunning ?? false) })}
+          disabled={disabled.leaveRunning}
+        />
       )}
       {show.env && (
         <div className="space-y-1">

--- a/web/src/components/launch-config-fields.tsx
+++ b/web/src/components/launch-config-fields.tsx
@@ -1,0 +1,270 @@
+/**
+ * LaunchConfigFields - Controlled form for launch/spawn configuration.
+ *
+ * Dumb component used by both SpawnDialog and RunTaskDialog. Parents own
+ * canonical state. The `show` mask controls which rows render; `disabled`
+ * toggles individual fields. No project-settings fetching, no spawn logic.
+ */
+
+import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS } from '@shared/spawn-schema'
+import type React from 'react'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+
+export type LaunchFieldKey =
+  | 'model'
+  | 'effort'
+  | 'permissionMode'
+  | 'autocompactPct'
+  | 'worktree'
+  | 'autoCommit'
+  | 'leaveRunning'
+  | 'maxBudgetUsd'
+  | 'timeout'
+  | 'name'
+  | 'env'
+
+export type LaunchFieldsValue = {
+  // Subset of SpawnRequest -- parent owns canonical state
+  model?: string
+  effort?: string
+  permissionMode?: string
+  autocompactPct?: number | ''
+  maxBudgetUsd?: string
+  name?: string
+  envText?: string
+
+  // Worktree: split into enable flag + branch name
+  useWorktree?: boolean
+  worktreeName?: string
+
+  // Prompt-suffix flags (not part of SpawnRequest)
+  autoCommit?: boolean
+  leaveRunning?: boolean
+
+  // RunTaskDialog-only
+  timeout?: string
+}
+
+export type LaunchFieldsProps = {
+  value: LaunchFieldsValue
+  onChange: (patch: Partial<LaunchFieldsValue>) => void
+  show?: Partial<Record<LaunchFieldKey, boolean>>
+  disabled?: Partial<Record<LaunchFieldKey, boolean>>
+}
+
+/** Tiny row component for label + right-aligned control. */
+function Row({ label, htmlFor, children }: { label: string; htmlFor?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <label htmlFor={htmlFor} className="text-[10px] font-mono text-muted-foreground shrink-0">
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }: LaunchFieldsProps) {
+  return (
+    <div className="space-y-3">
+      {show.model && (
+        <Row label="Model" htmlFor="lcf-model">
+          <div className="flex-1 max-w-[220px]">
+            <Select
+              value={value.model ? value.model : DEFAULT_SENTINEL}
+              onValueChange={v => onChange({ model: v === DEFAULT_SENTINEL ? '' : v })}
+              disabled={disabled.model}
+            >
+              <SelectTrigger id="lcf-model" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MODEL_OPTIONS.map(opt => (
+                  <SelectItem key={opt.value} value={opt.value} info={opt.info}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </Row>
+      )}
+      {show.effort && (
+        <Row label="Effort" htmlFor="lcf-effort">
+          <div className="flex-1 max-w-[220px]">
+            <Select
+              value={value.effort ? value.effort : DEFAULT_SENTINEL}
+              onValueChange={v => onChange({ effort: v === DEFAULT_SENTINEL ? '' : v })}
+              disabled={disabled.effort}
+            >
+              <SelectTrigger id="lcf-effort" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {EFFORT_OPTIONS.map(opt => (
+                  <SelectItem key={opt.value} value={opt.value} info={opt.info}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </Row>
+      )}
+      {show.permissionMode && (
+        <Row label="Permissions" htmlFor="lcf-permission">
+          <div className="flex-1 max-w-[220px]">
+            <Select
+              value={value.permissionMode ? value.permissionMode : DEFAULT_SENTINEL}
+              onValueChange={v => onChange({ permissionMode: v === DEFAULT_SENTINEL ? '' : v })}
+              disabled={disabled.permissionMode}
+            >
+              <SelectTrigger id="lcf-permission" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PERMISSION_MODE_OPTIONS.map(opt => (
+                  <SelectItem key={opt.value} value={opt.value} info={opt.info}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </Row>
+      )}
+      {show.autocompactPct && (
+        <Row label="Auto-compact %" htmlFor="lcf-compact">
+          <input
+            id="lcf-compact"
+            type="number"
+            min={0}
+            max={99}
+            value={value.autocompactPct ?? ''}
+            onChange={e => onChange({ autocompactPct: e.target.value === '' ? '' : Number(e.target.value) })}
+            disabled={disabled.autocompactPct}
+            className="w-[80px] text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+          />
+        </Row>
+      )}
+      {show.maxBudgetUsd && (
+        <Row label="Max budget USD" htmlFor="lcf-budget">
+          <input
+            id="lcf-budget"
+            type="number"
+            min={0}
+            step={0.01}
+            placeholder="(none)"
+            value={value.maxBudgetUsd ?? ''}
+            onChange={e => onChange({ maxBudgetUsd: e.target.value })}
+            disabled={disabled.maxBudgetUsd}
+            className="w-[100px] text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          />
+        </Row>
+      )}
+      {show.timeout && (
+        <Row label="Timeout" htmlFor="lcf-timeout">
+          <select
+            id="lcf-timeout"
+            value={value.timeout ?? ''}
+            onChange={e => onChange({ timeout: e.target.value })}
+            disabled={disabled.timeout}
+            className="text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+          >
+            <option value="5">5 min</option>
+            <option value="10">10 min</option>
+            <option value="15">15 min</option>
+            <option value="30">30 min</option>
+            <option value="0">unlimited</option>
+          </select>
+        </Row>
+      )}
+      {show.name && (
+        <Row label="Name" htmlFor="lcf-name">
+          <input
+            id="lcf-name"
+            type="text"
+            value={value.name ?? ''}
+            onChange={e => onChange({ name: e.target.value })}
+            disabled={disabled.name}
+            className="flex-1 max-w-[220px] text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+          />
+        </Row>
+      )}
+      {show.worktree && (
+        <div className="space-y-1.5">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={value.useWorktree ?? false}
+              onChange={e => onChange({ useWorktree: e.target.checked })}
+              disabled={disabled.worktree}
+              className="accent-amber-400"
+            />
+            <span className="text-[10px] font-mono text-muted-foreground">Use git worktree (isolated branch)</span>
+          </label>
+          {value.useWorktree && (
+            <input
+              type="text"
+              value={value.worktreeName ?? ''}
+              onChange={e => onChange({ worktreeName: e.target.value })}
+              disabled={disabled.worktree}
+              placeholder="Branch name..."
+              className="w-full text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+            />
+          )}
+        </div>
+      )}
+      {show.autoCommit && (
+        <div className="space-y-0.5">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={value.autoCommit ?? false}
+              onChange={e => onChange({ autoCommit: e.target.checked })}
+              disabled={disabled.autoCommit}
+              className="accent-amber-400"
+            />
+            <span className="text-[10px] font-mono text-muted-foreground">Auto-commit on completion</span>
+          </label>
+          <div className="text-[9px] text-[#565f89] pl-5">
+            Adds a prompt instruction to commit when the task finishes
+          </div>
+        </div>
+      )}
+      {show.leaveRunning && (
+        <div className="space-y-0.5">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={value.leaveRunning ?? false}
+              onChange={e => onChange({ leaveRunning: e.target.checked })}
+              disabled={disabled.leaveRunning}
+              className="accent-amber-400"
+            />
+            <span className="text-[10px] font-mono text-muted-foreground">Leave session running when done</span>
+          </label>
+          <div className="text-[9px] text-[#565f89] pl-5">
+            Keep session alive after the task completes for follow-up work
+          </div>
+        </div>
+      )}
+      {show.env && (
+        <div className="space-y-1">
+          <label htmlFor="lcf-env" className="text-[10px] font-mono text-muted-foreground">
+            Env (KEY=value per line)
+          </label>
+          <textarea
+            id="lcf-env"
+            value={value.envText ?? ''}
+            onChange={e => onChange({ envText: e.target.value })}
+            disabled={disabled.env}
+            rows={3}
+            spellCheck={false}
+            className="w-full text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/launch-config-fields.tsx
+++ b/web/src/components/launch-config-fields.tsx
@@ -8,9 +8,11 @@
 
 import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS } from '@shared/spawn-schema'
 import type React from 'react'
+import { useMemo } from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { TileToggleRow } from '@/components/ui/tile-toggle-row'
 import { TogglePill } from '@/components/ui/toggle-pill'
+import { parseEnvText } from '@/lib/env-parse'
 
 export type LaunchFieldKey =
   | 'model'
@@ -80,6 +82,14 @@ function Row({
 }
 
 export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }: LaunchFieldsProps) {
+  // Live env validation: recompute errors whenever envText changes so the user
+  // sees feedback as they type, rather than only on spawn/run submit.
+  const envErrors = useMemo(() => {
+    if (!show.env) return []
+    const [, errors] = parseEnvText(value.envText ?? '')
+    return errors
+  }, [show.env, value.envText])
+
   return (
     <div className="space-y-3">
       {show.model && (
@@ -147,22 +157,48 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </div>
       )}
       {show.autocompactPct && (
-        <Row
-          label="Auto-compact %"
-          subtitle="Compact context when usage hits this % of the window"
-          htmlFor="lcf-compact"
-        >
-          <input
-            id="lcf-compact"
-            type="number"
-            min={0}
-            max={99}
-            value={value.autocompactPct ?? ''}
-            onChange={e => onChange({ autocompactPct: e.target.value === '' ? '' : Number(e.target.value) })}
-            disabled={disabled.autocompactPct}
-            className="w-[80px] text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
-          />
-        </Row>
+        <div className="space-y-1.5">
+          <div className="flex items-baseline justify-between gap-3">
+            <div className="min-w-0">
+              <label htmlFor="lcf-compact" className="text-[10px] font-mono text-muted-foreground block">
+                Auto-compact %
+              </label>
+              <div className="text-[9px] text-[#565f89] mt-0.5 leading-snug">
+                Compact context when usage hits this % of the window
+              </div>
+            </div>
+            <div className="shrink-0 flex items-center gap-2 font-mono text-[11px] tabular-nums">
+              <span className={value.autocompactPct === '' ? 'text-[#565f89]' : 'text-[#7aa2f7]'}>
+                {value.autocompactPct === '' ? 'off' : `${value.autocompactPct}%`}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="lcf-compact"
+              type="range"
+              min={0}
+              max={99}
+              step={1}
+              value={value.autocompactPct === '' ? 0 : (value.autocompactPct ?? 0)}
+              onChange={e => {
+                const n = Number(e.target.value)
+                onChange({ autocompactPct: n === 0 ? '' : n })
+              }}
+              disabled={disabled.autocompactPct}
+              className="flex-1 accent-[#7aa2f7] cursor-pointer"
+            />
+            <button
+              type="button"
+              onClick={() => onChange({ autocompactPct: '' })}
+              disabled={disabled.autocompactPct || value.autocompactPct === ''}
+              className="text-[9px] font-mono text-[#565f89] hover:text-muted-foreground transition-colors disabled:opacity-30 disabled:hover:text-[#565f89]"
+              title="Disable auto-compact"
+            >
+              clear
+            </button>
+          </div>
+        </div>
       )}
       {show.maxBudgetUsd && (
         <Row
@@ -263,8 +299,17 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
             disabled={disabled.env}
             rows={3}
             spellCheck={false}
-            className="w-full text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
+            className={`w-full text-[10px] font-mono bg-[#1a1b26] border text-foreground px-2 py-1 outline-none transition-colors ${
+              envErrors.length > 0 ? 'border-red-500/50 focus-visible:border-red-500' : 'border-[#33467c]/50'
+            }`}
           />
+          {envErrors.length > 0 && (
+            <div className="text-[10px] font-mono text-red-400 space-y-0.5 pt-0.5">
+              {envErrors.map(e => (
+                <div key={e}>{e}</div>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/launch-config-fields.tsx
+++ b/web/src/components/launch-config-fields.tsx
@@ -54,14 +54,27 @@ export type LaunchFieldsProps = {
   disabled?: Partial<Record<LaunchFieldKey, boolean>>
 }
 
-/** Tiny row component for label + right-aligned control. */
-function Row({ label, htmlFor, children }: { label: string; htmlFor?: string; children: React.ReactNode }) {
+/** Tiny row component for label + right-aligned control. Optional subtitle. */
+function Row({
+  label,
+  subtitle,
+  htmlFor,
+  children,
+}: {
+  label: string
+  subtitle?: string
+  htmlFor?: string
+  children: React.ReactNode
+}) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <label htmlFor={htmlFor} className="text-[10px] font-mono text-muted-foreground shrink-0">
-        {label}
-      </label>
-      {children}
+    <div className="flex items-start justify-between gap-3 py-0.5">
+      <div className="min-w-0">
+        <label htmlFor={htmlFor} className="text-[10px] font-mono text-muted-foreground block">
+          {label}
+        </label>
+        {subtitle && <div className="text-[9px] text-[#565f89] mt-0.5 leading-snug">{subtitle}</div>}
+      </div>
+      <div className="shrink-0">{children}</div>
     </div>
   )
 }
@@ -70,7 +83,7 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
   return (
     <div className="space-y-3">
       {show.model && (
-        <Row label="Model" htmlFor="lcf-model">
+        <Row label="Model" subtitle="Claude model version" htmlFor="lcf-model">
           <div className="flex-1 max-w-[220px]">
             <Select
               value={value.model ? value.model : DEFAULT_SENTINEL}
@@ -92,7 +105,7 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </Row>
       )}
       {show.effort && (
-        <Row label="Effort" htmlFor="lcf-effort">
+        <Row label="Effort" subtitle="Thinking budget (higher = slower, deeper)" htmlFor="lcf-effort">
           <div className="flex-1 max-w-[220px]">
             <Select
               value={value.effort ? value.effort : DEFAULT_SENTINEL}
@@ -134,7 +147,11 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </div>
       )}
       {show.autocompactPct && (
-        <Row label="Auto-compact %" htmlFor="lcf-compact">
+        <Row
+          label="Auto-compact %"
+          subtitle="Compact context when usage hits this % of the window"
+          htmlFor="lcf-compact"
+        >
           <input
             id="lcf-compact"
             type="number"
@@ -148,7 +165,11 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </Row>
       )}
       {show.maxBudgetUsd && (
-        <Row label="Max budget USD" htmlFor="lcf-budget">
+        <Row
+          label="Max budget USD"
+          subtitle="Stop session when spend reaches this (blank = no limit)"
+          htmlFor="lcf-budget"
+        >
           <input
             id="lcf-budget"
             type="number"
@@ -163,7 +184,7 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </Row>
       )}
       {show.timeout && (
-        <Row label="Timeout" htmlFor="lcf-timeout">
+        <Row label="Timeout" subtitle="Max runtime before forced stop" htmlFor="lcf-timeout">
           <select
             id="lcf-timeout"
             value={value.timeout ?? ''}
@@ -180,7 +201,7 @@ export function LaunchConfigFields({ value, onChange, show = {}, disabled = {} }
         </Row>
       )}
       {show.name && (
-        <Row label="Name" htmlFor="lcf-name">
+        <Row label="Name" subtitle="Display label in sidebar" htmlFor="lcf-name">
           <input
             id="lcf-name"
             type="text"

--- a/web/src/components/launch-monitor.tsx
+++ b/web/src/components/launch-monitor.tsx
@@ -8,7 +8,8 @@
  *   LaunchMonitor     - Full modal wrapper (used by ReviveMonitor)
  */
 
-import { Copy, X, Zap } from 'lucide-react'
+import { Copy, Zap } from 'lucide-react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Kbd } from '@/components/ui/kbd'
 import type { LaunchStep } from '@/hooks/use-launch-progress'
 import { cn } from '@/lib/utils'
@@ -186,24 +187,9 @@ export function LaunchMonitor({
   const accent = ACCENT[accentColor]
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: modal backdrop
-    <div
-      role="button"
-      tabIndex={-1}
-      aria-label="Close dialog"
-      className="fixed inset-0 z-[110] flex items-center justify-center p-4"
-      onClick={onClose}
-      onKeyDown={e => {
-        if (e.key === 'Escape') onClose()
-      }}
-    >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-      <div
-        role="dialog"
-        className={cn('relative w-full max-w-md bg-[#1a1b26] border shadow-2xl', accent.border)}
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => e.stopPropagation()}
-      >
+    <Dialog open={true} onOpenChange={open => !open && onClose()}>
+      <DialogContent className={cn('max-w-md rounded-lg p-0 gap-0 bg-[#1a1b26]', accent.border)}>
+        <DialogTitle className="sr-only">{title}</DialogTitle>
         {/* Header */}
         <div className={cn('flex items-center gap-2 px-4 py-3 border-b', accent.headerBorder)}>
           <Zap className={cn('w-4 h-4', accent.text)} />
@@ -213,13 +199,6 @@ export function LaunchMonitor({
           {steps.length > 0 && (
             <span className="text-[10px] font-mono text-muted-foreground/60 ml-auto mr-2 tabular-nums">{elapsed}s</span>
           )}
-          <button
-            type="button"
-            onClick={onClose}
-            className={cn('text-muted-foreground hover:text-foreground', steps.length === 0 && 'ml-auto')}
-          >
-            <X className="w-4 h-4" />
-          </button>
         </div>
 
         {/* Subtitle */}
@@ -259,7 +238,7 @@ export function LaunchMonitor({
             />
           </div>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/web/src/components/nerd-modal.tsx
+++ b/web/src/components/nerd-modal.tsx
@@ -4,10 +4,10 @@
  */
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useSessionsStore } from '@/hooks/use-sessions'
 import { getRates, subscribe as subscribeStats } from '@/hooks/ws-stats'
 import { clearLog, copyLogText, getLogEntries, subscribeLog } from '@/lib/debug-log'
-import { useKeyLayer } from '@/lib/key-layers'
 import {
   categoryStats,
   clearEntries as clearPerfEntries,
@@ -526,10 +526,6 @@ export function NerdModal({ open, onClose }: { open: boolean; onClose: () => voi
     return () => clearInterval(id)
   }, [open, fetchStats])
 
-  useKeyLayer({ Escape: () => onClose() }, { id: 'nerd-modal', enabled: open })
-
-  if (!open) return null
-
   const tabs: { id: Tab; label: string }[] = [
     { id: 'cache', label: 'Cache' },
     { id: 'traffic', label: 'Traffic' },
@@ -539,16 +535,10 @@ export function NerdModal({ open, onClose }: { open: boolean; onClose: () => voi
   ]
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: Escape handled via window listener
-    // biome-ignore lint/a11y/noStaticElementInteractions: modal backdrop
-    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50" onClick={onClose}>
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation */}
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: modal panel */}
-      <div
-        className="w-full max-w-lg max-h-[80vh] overflow-hidden bg-[#16161e] border border-[#33467c] shadow-2xl font-mono flex flex-col"
-        onClick={e => e.stopPropagation()}
-      >
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-hidden font-mono flex flex-col p-0">
         <div className="p-4 pb-0">
+          <DialogTitle className="sr-only">Details for Nerds</DialogTitle>
           <pre className="text-[#7aa2f7] text-[10px] leading-tight mb-3 select-none text-center">
             {`┌─────────────────────────────────┐
 │      DETAILS FOR NERDS          │
@@ -585,7 +575,7 @@ export function NerdModal({ open, onClose }: { open: boolean; onClose: () => voi
         <div className="text-center text-[10px] text-[#565f89] py-2 border-t border-[#33467c]/30">
           <kbd className="px-1 py-0.5 bg-[#33467c]/30 text-[#7aa2f7]">Esc</kbd> to close
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -16,7 +16,7 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import { composeSpawnPrompt } from '@shared/spawn-prompt'
-import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS } from '@shared/spawn-schema'
+import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, type SpawnRequest } from '@shared/spawn-schema'
 import {
   Archive,
   ArrowLeft,
@@ -39,6 +39,7 @@ import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import type { ProjectTask } from '@/hooks/use-project'
 import { type ProjectTaskMeta, type TaskStatus, useProject } from '@/hooks/use-project'
 import { sendInput, useSessionsStore } from '@/hooks/use-sessions'
+import { sendSpawnRequest } from '@/hooks/use-spawn'
 import { useKeyLayer } from '@/lib/key-layers'
 import { buildTaskPrompt } from '@/lib/task-scoring'
 import { uploadFileWithPlaceholder } from '@/lib/upload'
@@ -751,41 +752,33 @@ export function RunTaskDialog({
       worktreeMergeBack: useWorktree,
     })
 
-    try {
-      const res = await fetch('/api/spawn', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          cwd,
-          adHoc: true,
-          adHocTaskId: task.slug,
-          prompt,
-          headless: true,
-          model: model || undefined,
-          effort: effort !== 'default' ? effort : undefined,
-          worktree: useWorktree ? branchName : undefined,
-          leaveRunning: leaveRunning || undefined,
-          name: task.title.replace(/['"]/g, '').slice(0, 60),
-          maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
-          jobId: newJobId,
-        }),
-      })
-      const data = await res.json()
-      if (data.success) {
-        haptic('success')
-        const wid = data.wrapperId as string
-        setWrapperId(wid)
-        progress.setSteps(prev => [
-          ...prev.map(s =>
-            s.status === 'active' ? { ...s, status: 'done' as const, detail: `wrapper=${wid.slice(0, 8)}` } : s,
-          ),
-          { label: 'Waiting for session...', status: 'active' as const, ts: Date.now() },
-        ])
-      } else {
-        progress.setError(data.error || 'Spawn failed')
-      }
-    } catch (err: unknown) {
-      progress.setError(err instanceof Error ? err.message : 'Network error')
+    const spawnReq: SpawnRequest = {
+      cwd,
+      adHoc: true,
+      adHocTaskId: task.slug,
+      prompt,
+      headless: true,
+      model: (model || undefined) as SpawnRequest['model'],
+      effort: (effort !== 'default' ? effort : undefined) as SpawnRequest['effort'],
+      worktree: useWorktree ? branchName : undefined,
+      leaveRunning: leaveRunning || undefined,
+      name: task.title.replace(/['"]/g, '').slice(0, 60),
+      maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
+      jobId: newJobId,
+    }
+    const result = await sendSpawnRequest(spawnReq)
+    if (result.ok) {
+      haptic('success')
+      const wid = result.wrapperId
+      setWrapperId(wid)
+      progress.setSteps(prev => [
+        ...prev.map(s =>
+          s.status === 'active' ? { ...s, status: 'done' as const, detail: `wrapper=${wid.slice(0, 8)}` } : s,
+        ),
+        { label: 'Waiting for session...', status: 'active' as const, ts: Date.now() },
+      ])
+    } else {
+      progress.setError(result.error)
     }
   }
 

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -15,6 +15,8 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { buildSpawnDiagnostics } from '@shared/spawn-diagnostics'
+import { deriveSessionName } from '@shared/spawn-naming'
 import { composeSpawnPrompt } from '@shared/spawn-prompt'
 import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, type SpawnRequest } from '@shared/spawn-schema'
 import {
@@ -762,7 +764,11 @@ export function RunTaskDialog({
       effort: (effort !== 'default' ? effort : undefined) as SpawnRequest['effort'],
       worktree: useWorktree ? branchName : undefined,
       leaveRunning: leaveRunning || undefined,
-      name: task.title.replace(/['"]/g, '').slice(0, 60),
+      name:
+        deriveSessionName(
+          {},
+          { slug: task.slug, title: task.title, status: task.status, priority: task.priority, tags: task.tags },
+        ) ?? undefined,
       maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
       jobId: newJobId,
     }
@@ -792,39 +798,36 @@ export function RunTaskDialog({
   }
 
   function handleCopyDiagnostics() {
-    const diag = {
-      type: 'run_task_diagnostics',
-      time: new Date().toISOString(),
-      task: { slug: task.slug, title: task.title, status: task.status, priority: task.priority, tags: task.tags },
-      cwd,
+    const diag = buildSpawnDiagnostics({
+      source: 'run-task-dialog',
       jobId,
       wrapperId: wrapperId || progress.launch.wrapperId || null,
-      sessionId: progress.launch.sessionId || null,
-      elapsed: `${progress.elapsed}s`,
+      sessionId: progress.launch.sessionId ?? null,
+      elapsedSec: progress.elapsed,
       error: progress.error || progress.launch.error || null,
       config: {
-        model: model || null,
-        effort,
-        worktree: useWorktree ? branchName : null,
-        autoCommit,
-        leaveRunning,
-        maxBudgetUsd: maxBudgetUsd || null,
-        timeout,
+        cwd: cwd || undefined,
+        model: (model || undefined) as SpawnRequest['model'],
+        effort: (effort !== 'default' ? effort : undefined) as SpawnRequest['effort'],
+        worktree: useWorktree ? branchName : undefined,
+        leaveRunning: leaveRunning || undefined,
+        maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
       },
       steps: progress.steps.map(s => ({
         label: s.label,
         status: s.status,
-        detail: s.detail || null,
-        ts: s.ts || null,
+        detail: s.detail ?? null,
+        ts: s.ts ?? null,
       })),
       launchEvents: progress.launch.events.map(e => ({
         step: e.step,
         status: e.status,
-        detail: e.detail || null,
+        detail: e.detail ?? null,
         t: e.t,
       })),
       launchState: { completed: progress.launch.completed, failed: progress.launch.failed },
-    }
+      task: { slug: task.slug, title: task.title, status: task.status, priority: task.priority, tags: task.tags },
+    })
     progress.copyToClipboard(JSON.stringify(diag, null, 2))
   }
 

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -15,6 +15,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS } from '@shared/spawn-schema'
 import {
   Archive,
   ArrowLeft,
@@ -32,6 +33,7 @@ import {
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Kbd } from '@/components/ui/kbd'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import type { ProjectTask } from '@/hooks/use-project'
 import { type ProjectTaskMeta, type TaskStatus, useProject } from '@/hooks/use-project'
@@ -887,39 +889,49 @@ export function RunTaskDialog({
         {phase === 'config' && (
           <>
             <div className="px-4 py-3 space-y-3">
-              <div className="flex items-center justify-between">
-                <label htmlFor="run-task-model" className="text-[10px] font-mono text-muted-foreground">
+              <div className="flex items-center justify-between gap-3">
+                <label htmlFor="run-task-model" className="text-[10px] font-mono text-muted-foreground shrink-0">
                   Model
                 </label>
-                <select
-                  id="run-task-model"
-                  value={model}
-                  onChange={e => setModel(e.target.value)}
-                  className="text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
-                >
-                  <option value="">default</option>
-                  <option value="opus">opus</option>
-                  <option value="sonnet">sonnet</option>
-                  <option value="haiku">haiku</option>
-                </select>
+                <div className="flex-1 max-w-[220px]">
+                  <Select
+                    value={model === '' ? DEFAULT_SENTINEL : model}
+                    onValueChange={v => setModel(v === DEFAULT_SENTINEL ? '' : v)}
+                  >
+                    <SelectTrigger id="run-task-model" size="sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MODEL_OPTIONS.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value} info={opt.info}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="run-task-effort" className="text-[10px] font-mono text-muted-foreground">
+              <div className="flex items-center justify-between gap-3">
+                <label htmlFor="run-task-effort" className="text-[10px] font-mono text-muted-foreground shrink-0">
                   Effort
                 </label>
-                <select
-                  id="run-task-effort"
-                  value={effort}
-                  onChange={e => setEffort(e.target.value)}
-                  className="text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
-                >
-                  <option value="default">default</option>
-                  <option value="low">low</option>
-                  <option value="medium">medium</option>
-                  <option value="high">high</option>
-                  <option value="xhigh">xhigh</option>
-                  <option value="max">max</option>
-                </select>
+                <div className="flex-1 max-w-[220px]">
+                  <Select
+                    value={effort === '' || effort === 'default' ? DEFAULT_SENTINEL : effort}
+                    onValueChange={v => setEffort(v === DEFAULT_SENTINEL ? 'default' : v)}
+                  >
+                    <SelectTrigger id="run-task-effort" size="sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EFFORT_OPTIONS.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value} info={opt.info}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
               <div className="space-y-1.5">
                 <label className="flex items-center gap-2 cursor-pointer">

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -244,8 +244,8 @@ export function TaskEditor({
 
   useKeyLayer(
     {
-      Escape: () => onClose(),
-      // Bare keys -- auto-blocked when a text input / CodeMirror is focused
+      // Bare keys -- auto-blocked when a text input / CodeMirror is focused.
+      // Radix Dialog handles Escape itself via onOpenChange.
       w: () => {
         if (!canWork) return
         sendInput(sessionId, buildTaskPrompt({ ...task, title, body, status, priority, tags }))
@@ -331,15 +331,9 @@ export function TaskEditor({
   }
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop
-    <div role="presentation" className="fixed inset-0 z-[100] flex items-center justify-center p-4" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-      <div
-        role="dialog"
-        className="relative w-full max-w-2xl bg-[#1a1b26] border border-[#33467c] shadow-2xl flex flex-col max-h-[80vh]"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => e.stopPropagation()}
-      >
+    <Dialog open={true} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col p-0">
+        <DialogTitle className="sr-only">Edit task: {title}</DialogTitle>
         {/* Header */}
         <div className="flex items-center gap-2 px-4 py-3 border-b border-[#33467c]/50 shrink-0">
           <input
@@ -610,8 +604,8 @@ export function TaskEditor({
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -35,6 +35,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Kbd } from '@/components/ui/kbd'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import type { ProjectTask } from '@/hooks/use-project'
@@ -834,24 +835,9 @@ export function RunTaskDialog({
   const displayError = progress.error || progress.launch.error
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: modal backdrop
-    <div
-      role="button"
-      tabIndex={-1}
-      aria-label="Close dialog"
-      className="fixed inset-0 z-[110] flex items-center justify-center p-4"
-      onClick={onClose}
-      onKeyDown={e => {
-        if (e.key === 'Escape') onClose()
-      }}
-    >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-      <div
-        role="dialog"
-        className="relative w-full max-w-md bg-[#1a1b26] border border-amber-500/30 shadow-2xl"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => e.stopPropagation()}
-      >
+    <Dialog open={true} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-md rounded-lg p-0 gap-0 bg-[#1a1b26] border-amber-500/30">
+        <DialogTitle className="sr-only">Run Task: {task.title}</DialogTitle>
         {/* Header */}
         <div className="flex items-center gap-2 px-4 py-3 border-b border-amber-500/20">
           <Zap className="w-4 h-4 text-amber-400" />
@@ -869,9 +855,6 @@ export function RunTaskDialog({
               {progress.elapsed}s
             </span>
           )}
-          <button type="button" onClick={onClose} className="ml-auto text-muted-foreground hover:text-foreground">
-            <X className="w-4 h-4" />
-          </button>
         </div>
 
         {/* Task title */}
@@ -971,8 +954,8 @@ export function RunTaskDialog({
             </div>
           </>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -650,7 +650,6 @@ export function RunTaskDialog({
   })
 
   useKeyLayer({
-    Escape: onClose,
     Enter: () => {
       if (phase === 'config') handleRun()
       else if (progress.isConnected) handleViewSession()

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -18,7 +18,7 @@ import {
 import { buildSpawnDiagnostics } from '@shared/spawn-diagnostics'
 import { deriveSessionName } from '@shared/spawn-naming'
 import { composeSpawnPrompt } from '@shared/spawn-prompt'
-import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, type SpawnRequest } from '@shared/spawn-schema'
+import type { SpawnRequest } from '@shared/spawn-schema'
 import {
   Archive,
   ArrowLeft,
@@ -36,7 +36,6 @@ import {
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Kbd } from '@/components/ui/kbd'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import type { ProjectTask } from '@/hooks/use-project'
 import { type ProjectTaskMeta, type TaskStatus, useProject } from '@/hooks/use-project'
@@ -46,6 +45,7 @@ import { useKeyLayer } from '@/lib/key-layers'
 import { buildTaskPrompt } from '@/lib/task-scoring'
 import { uploadFileWithPlaceholder } from '@/lib/upload'
 import { cn, haptic } from '@/lib/utils'
+import { LaunchConfigFields, type LaunchFieldsValue } from './launch-config-fields'
 import { LaunchErrorBanner, LaunchFooterActions, LaunchStepList } from './launch-monitor'
 import { Markdown } from './markdown'
 import { MarkdownInput } from './markdown-input'
@@ -885,136 +885,38 @@ export function RunTaskDialog({
         {/* Phase 1: Config form */}
         {phase === 'config' && (
           <>
-            <div className="px-4 py-3 space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <label htmlFor="run-task-model" className="text-[10px] font-mono text-muted-foreground shrink-0">
-                  Model
-                </label>
-                <div className="flex-1 max-w-[220px]">
-                  <Select
-                    value={model === '' ? DEFAULT_SENTINEL : model}
-                    onValueChange={v => setModel(v === DEFAULT_SENTINEL ? '' : v)}
-                  >
-                    <SelectTrigger id="run-task-model" size="sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {MODEL_OPTIONS.map(opt => (
-                        <SelectItem key={opt.value} value={opt.value} info={opt.info}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <label htmlFor="run-task-effort" className="text-[10px] font-mono text-muted-foreground shrink-0">
-                  Effort
-                </label>
-                <div className="flex-1 max-w-[220px]">
-                  <Select
-                    value={effort === '' || effort === 'default' ? DEFAULT_SENTINEL : effort}
-                    onValueChange={v => setEffort(v === DEFAULT_SENTINEL ? 'default' : v)}
-                  >
-                    <SelectTrigger id="run-task-effort" size="sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {EFFORT_OPTIONS.map(opt => (
-                        <SelectItem key={opt.value} value={opt.value} info={opt.info}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={useWorktree}
-                    onChange={e => setUseWorktree(e.target.checked)}
-                    className="accent-amber-400"
-                  />
-                  <span className="text-[10px] font-mono text-muted-foreground">
-                    Use git worktree (isolated branch)
-                  </span>
-                </label>
-                {useWorktree && (
-                  <input
-                    type="text"
-                    value={branchName}
-                    onChange={e => setBranchName(e.target.value)}
-                    className="w-full text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
-                    placeholder="Branch name..."
-                  />
-                )}
-              </div>
-              <div className="space-y-0.5">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={autoCommit}
-                    onChange={e => setAutoCommit(e.target.checked)}
-                    className="accent-amber-400"
-                  />
-                  <span className="text-[10px] font-mono text-muted-foreground">Auto-commit on completion</span>
-                </label>
-                <div className="text-[9px] text-[#565f89] pl-5">
-                  Adds a prompt instruction to commit when the task finishes
-                </div>
-              </div>
-              <div className="space-y-0.5">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={leaveRunning}
-                    onChange={e => setLeaveRunning(e.target.checked)}
-                    className="accent-amber-400"
-                  />
-                  <span className="text-[10px] font-mono text-muted-foreground">Leave session running when done</span>
-                </label>
-                <div className="text-[9px] text-[#565f89] pl-5">
-                  Keep session alive after the task completes for follow-up work
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="run-task-budget" className="text-[10px] font-mono text-muted-foreground">
-                  Max budget
-                </label>
-                <div className="flex items-center gap-1">
-                  <span className="text-[10px] text-[#565f89]">$</span>
-                  <input
-                    id="run-task-budget"
-                    type="number"
-                    min={0.01}
-                    step={0.01}
-                    placeholder="none"
-                    value={maxBudgetUsd}
-                    onChange={e => setMaxBudgetUsd(e.target.value)}
-                    className="w-16 text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  />
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="run-task-timeout" className="text-[10px] font-mono text-muted-foreground">
-                  Timeout
-                </label>
-                <select
-                  id="run-task-timeout"
-                  value={timeout}
-                  onChange={e => setTimeout_(e.target.value)}
-                  className="text-[10px] font-mono bg-[#1a1b26] border border-[#33467c]/50 text-foreground px-2 py-1 outline-none"
-                >
-                  <option value="5">5 min</option>
-                  <option value="10">10 min</option>
-                  <option value="15">15 min</option>
-                  <option value="30">30 min</option>
-                  <option value="0">unlimited</option>
-                </select>
-              </div>
+            <div className="px-4 py-3">
+              <LaunchConfigFields
+                value={{
+                  model,
+                  effort: effort === 'default' ? '' : effort,
+                  useWorktree,
+                  worktreeName: branchName,
+                  autoCommit,
+                  leaveRunning,
+                  maxBudgetUsd,
+                  timeout,
+                }}
+                onChange={(patch: Partial<LaunchFieldsValue>) => {
+                  if ('model' in patch) setModel(patch.model ?? '')
+                  if ('effort' in patch) setEffort(patch.effort ? patch.effort : 'default')
+                  if ('useWorktree' in patch) setUseWorktree(!!patch.useWorktree)
+                  if ('worktreeName' in patch) setBranchName(patch.worktreeName ?? '')
+                  if ('autoCommit' in patch) setAutoCommit(!!patch.autoCommit)
+                  if ('leaveRunning' in patch) setLeaveRunning(!!patch.leaveRunning)
+                  if ('maxBudgetUsd' in patch) setMaxBudgetUsd(patch.maxBudgetUsd ?? '')
+                  if ('timeout' in patch) setTimeout_(patch.timeout ?? '30')
+                }}
+                show={{
+                  model: true,
+                  effort: true,
+                  worktree: true,
+                  autoCommit: true,
+                  leaveRunning: true,
+                  maxBudgetUsd: true,
+                  timeout: true,
+                }}
+              />
             </div>
             <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-[#33467c]/30">
               <button

--- a/web/src/components/project-board.tsx
+++ b/web/src/components/project-board.tsx
@@ -15,6 +15,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { composeSpawnPrompt } from '@shared/spawn-prompt'
 import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS } from '@shared/spawn-schema'
 import {
   Archive,
@@ -744,11 +745,11 @@ export function RunTaskDialog({
     setJobId(newJobId)
     progress.start([{ label: 'Sending spawn request...', status: 'active', ts: Date.now() }])
 
-    const commitLine = autoCommit ? '\n\nWhen you are done, commit all changes with a descriptive commit message.' : ''
-    const worktreeMerge = useWorktree
-      ? '\n\nIMPORTANT - WORKTREE MERGE-BACK:\nYou are working in a git worktree (isolated branch). Before finishing:\n1. Commit all changes\n2. Merge back to main: run `git rebase main && git fetch . HEAD:main`\n3. If rebase conflicts occur, resolve them and run `git rebase --continue`, then `git fetch . HEAD:main`\n4. Verify: `git log --oneline main -5`\nThis merges your work back to main so it is not stranded on a dead branch.'
-      : ''
-    const prompt = buildTaskPrompt(task, `${commitLine}${worktreeMerge}`)
+    const prompt = composeSpawnPrompt('', {
+      taskWrapper: task,
+      autoCommit,
+      worktreeMergeBack: useWorktree,
+    })
 
     try {
       const res = await fetch('/api/spawn', {

--- a/web/src/components/quick-task-modal.tsx
+++ b/web/src/components/quick-task-modal.tsx
@@ -3,14 +3,14 @@
  * Creates a project task in .rclaude/project/inbox/
  */
 
-import { AlertTriangle, FileText, X } from 'lucide-react'
+import { AlertTriangle, FileText } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useProject } from '@/hooks/use-project'
 import { useSessionsStore } from '@/hooks/use-sessions'
 import { useCommand } from '@/lib/commands'
-import { useKeyLayer } from '@/lib/key-layers'
 import { haptic } from '@/lib/utils'
 import { MarkdownInput } from './markdown-input'
+import { Dialog, DialogContent, DialogTitle } from './ui/dialog'
 import { Kbd, KbdGroup } from './ui/kbd'
 
 export function QuickTaskModal() {
@@ -63,16 +63,11 @@ export function QuickTaskModal() {
     return () => window.removeEventListener('open-quick-task', handleOpen)
   }, [selectedSessionId, isActive])
 
-  // ESC closes when open
-  useKeyLayer(
-    {
-      Escape: () => {
-        setOpen(false)
-        setText('')
-      },
-    },
-    { id: 'quick-task', enabled: open },
-  )
+  // Radix Dialog handles Escape natively; clear text on close via onOpenChange.
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+    if (!next) setText('')
+  }, [])
 
   const handleSubmit = useCallback(() => {
     if (!text.trim() || !hasWrapper) return
@@ -94,92 +89,60 @@ export function QuickTaskModal() {
     setTimeout(() => setFlash(false), 1000)
   }, [text, createTask, hasWrapper, selectedSessionId])
 
-  if (!open) {
-    if (flash) {
-      return (
+  return (
+    <>
+      {flash && !open && (
         <div className="fixed bottom-4 right-4 z-[100] px-3 py-1.5 bg-emerald-500/20 border border-emerald-500/50 text-emerald-400 text-xs font-mono animate-pulse">
           Task created
         </div>
-      )
-    }
-    return null
-  }
-
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay closes on click
-    <div
-      role="presentation"
-      className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]"
-      onClick={() => setOpen(false)}
-      onKeyDown={e => {
-        if (e.key === 'Escape') setOpen(false)
-      }}
-    >
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
-      <div
-        role="dialog"
-        className="relative w-full max-w-lg mx-4 bg-background border border-border shadow-2xl flex flex-col max-h-[50vh]"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => {
-          if (e.key === 'Escape') {
-            setOpen(false)
-            setText('')
-          } else {
-            e.stopPropagation()
-          }
-        }}
-      >
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border shrink-0">
-          <FileText className="w-4 h-4 text-accent" />
-          <span className="text-xs font-bold text-foreground">Quick Task</span>
-          <span className="text-[10px] text-muted-foreground ml-1">project task</span>
-          <button
-            type="button"
-            onClick={() => setOpen(false)}
-            className="ml-auto text-muted-foreground hover:text-foreground"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
-        {!hasWrapper && (
-          <div className="flex items-center gap-2 px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 text-amber-400">
-            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
-            <span className="text-[10px] font-mono">No wrapper connected -- task cannot be delivered</span>
+      )}
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-lg max-h-[50vh] flex flex-col p-0 top-[15vh] translate-y-0">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-border shrink-0">
+            <FileText className="w-4 h-4 text-accent" />
+            <DialogTitle className="text-xs">Quick Task</DialogTitle>
+            <span className="text-[10px] text-muted-foreground ml-1">project task</span>
           </div>
-        )}
-        <div className="p-3 flex-1 min-h-0">
-          <MarkdownInput
-            value={text}
-            onChange={setText}
-            onSubmit={handleSubmit}
-            placeholder="First line = title, rest = body... Shift+Enter for new line"
-            autoFocus
-            inline
-          />
-        </div>
-        <div className="flex items-center justify-between px-3 py-2 border-t border-border shrink-0">
-          <span className="text-[10px] text-muted-foreground flex items-center gap-1.5">
-            <Kbd>↵</Kbd> add
-            <span className="text-muted-foreground/40">·</span>
-            <KbdGroup>
-              <Kbd>⇧</Kbd>
-              <Kbd>↵</Kbd>
-            </KbdGroup>{' '}
-            newline
-            <span className="text-muted-foreground/40">·</span>
-            <Kbd>Esc</Kbd> close
-          </span>
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={!text.trim() || !hasWrapper}
-            className="flex items-center gap-1.5 px-3 py-1 text-xs font-bold bg-accent/20 text-accent hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Add
-            <Kbd className="bg-accent/20 text-accent/70">↵</Kbd>
-          </button>
-        </div>
-      </div>
-    </div>
+          {!hasWrapper && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 text-amber-400">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+              <span className="text-[10px] font-mono">No wrapper connected -- task cannot be delivered</span>
+            </div>
+          )}
+          <div className="p-3 flex-1 min-h-0">
+            <MarkdownInput
+              value={text}
+              onChange={setText}
+              onSubmit={handleSubmit}
+              placeholder="First line = title, rest = body... Shift+Enter for new line"
+              autoFocus
+              inline
+            />
+          </div>
+          <div className="flex items-center justify-between px-3 py-2 border-t border-border shrink-0">
+            <span className="text-[10px] text-muted-foreground flex items-center gap-1.5">
+              <Kbd>↵</Kbd> add
+              <span className="text-muted-foreground/40">·</span>
+              <KbdGroup>
+                <Kbd>⇧</Kbd>
+                <Kbd>↵</Kbd>
+              </KbdGroup>{' '}
+              newline
+              <span className="text-muted-foreground/40">·</span>
+              <Kbd>Esc</Kbd> close
+            </span>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!text.trim() || !hasWrapper}
+              className="flex items-center gap-1.5 px-3 py-1 text-xs font-bold bg-accent/20 text-accent hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Add
+              <Kbd className="bg-accent/20 text-accent/70">↵</Kbd>
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/web/src/components/shortcut-help.tsx
+++ b/web/src/components/shortcut-help.tsx
@@ -4,8 +4,8 @@
  */
 
 import { useMemo, useState } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { formatShortcut, getCommandGeneration, getCommands, useCommand } from '@/lib/commands'
-import { useKeyLayer } from '@/lib/key-layers'
 
 const INPUT_SHORTCUTS = [
   { keys: 'Enter', action: 'Send message' },
@@ -22,7 +22,6 @@ export function ShortcutHelp() {
     shortcut: 'shift+?',
     group: 'Help',
   })
-  useKeyLayer({ Escape: () => setOpen(false) }, { id: 'shortcut-help', enabled: open })
 
   const _gen = getCommandGeneration()
   // biome-ignore lint/correctness/useExhaustiveDependencies: _gen is a generation counter dep key that invalidates memoized command list when registry changes
@@ -34,23 +33,13 @@ export function ShortcutHelp() {
     [_gen],
   )
 
-  if (!open) return null
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay closes on click
-    <div
-      role="presentation"
-      className="fixed inset-0 z-[70] flex items-center justify-center"
-      onClick={() => setOpen(false)}
-    >
-      <div
-        role="dialog"
-        className="w-full max-w-md bg-[#16161e] border border-[#33467c] shadow-2xl font-mono p-6"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => e.stopPropagation()}
-      >
-        <pre className="text-[#7aa2f7] text-[10px] leading-tight mb-4 select-none">
-          {`┌──────────────────────────────────────┐
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md">
+        <div className="font-mono p-6">
+          <DialogTitle className="sr-only">Keyboard Shortcuts</DialogTitle>
+          <pre className="text-[#7aa2f7] text-[10px] leading-tight mb-4 select-none">
+            {`┌──────────────────────────────────────┐
 │  ██╗  ██╗███████╗██╗   ██╗███████╗  │
 │  ██║ ██╔╝██╔════╝╚██╗ ██╔╝██╔════╝  │
 │  █████╔╝ █████╗   ╚████╔╝ ███████╗  │
@@ -58,33 +47,34 @@ export function ShortcutHelp() {
 │  ██║  ██╗███████╗   ██║   ███████║  │
 │  ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝  │
 └──────────────────────────────────────┘`}
-        </pre>
+          </pre>
 
-        <div className="mb-4">
-          <div className="text-[10px] uppercase tracking-wider text-[#565f89] mb-2">Global</div>
-          {shortcuts.map(s => (
-            <div key={s.keys} className="flex items-center justify-between py-1 border-b border-[#33467c]/30">
-              <kbd className="px-1.5 py-0.5 bg-[#33467c]/40 text-[#7aa2f7] text-[11px]">{s.keys}</kbd>
-              <span className="text-[11px] text-[#a9b1d6]">{s.action}</span>
-            </div>
-          ))}
-        </div>
+          <div className="mb-4">
+            <div className="text-[10px] uppercase tracking-wider text-[#565f89] mb-2">Global</div>
+            {shortcuts.map(s => (
+              <div key={s.keys} className="flex items-center justify-between py-1 border-b border-[#33467c]/30">
+                <kbd className="px-1.5 py-0.5 bg-[#33467c]/40 text-[#7aa2f7] text-[11px]">{s.keys}</kbd>
+                <span className="text-[11px] text-[#a9b1d6]">{s.action}</span>
+              </div>
+            ))}
+          </div>
 
-        <div className="mb-4">
-          <div className="text-[10px] uppercase tracking-wider text-[#565f89] mb-2">Input Bar</div>
-          {INPUT_SHORTCUTS.map(s => (
-            <div key={s.keys} className="flex items-center justify-between py-1 border-b border-[#33467c]/30">
-              <kbd className="px-1.5 py-0.5 bg-[#33467c]/40 text-[#7aa2f7] text-[11px]">{s.keys}</kbd>
-              <span className="text-[11px] text-[#a9b1d6]">{s.action}</span>
-            </div>
-          ))}
-        </div>
+          <div className="mb-4">
+            <div className="text-[10px] uppercase tracking-wider text-[#565f89] mb-2">Input Bar</div>
+            {INPUT_SHORTCUTS.map(s => (
+              <div key={s.keys} className="flex items-center justify-between py-1 border-b border-[#33467c]/30">
+                <kbd className="px-1.5 py-0.5 bg-[#33467c]/40 text-[#7aa2f7] text-[11px]">{s.keys}</kbd>
+                <span className="text-[11px] text-[#a9b1d6]">{s.action}</span>
+              </div>
+            ))}
+          </div>
 
-        <div className="text-center text-[10px] text-[#565f89]">
-          Press <kbd className="px-1 py-0.5 bg-[#33467c]/30 text-[#7aa2f7]">Esc</kbd> or{' '}
-          <kbd className="px-1 py-0.5 bg-[#33467c]/30 text-[#7aa2f7]">Shift+?</kbd> to close
+          <div className="text-center text-[10px] text-[#565f89]">
+            Press <kbd className="px-1 py-0.5 bg-[#33467c]/30 text-[#7aa2f7]">Esc</kbd> or{' '}
+            <kbd className="px-1 py-0.5 bg-[#33467c]/30 text-[#7aa2f7]">Shift+?</kbd> to close
+          </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -472,8 +472,11 @@ export function SpawnDialog() {
                 </button>
               </div>
 
-              {/* Scrollable content area */}
-              <div className="overflow-y-auto flex-1 min-h-0 space-y-4 px-0.5">
+              {/* Scrollable content area.
+                  Inner padding gives focus rings (ring-[3px]) room; without
+                  this, overflow-y:auto implicitly clips overflow-x and the
+                  blue focus ring on inputs/selects gets sliced off. */}
+              <div className="overflow-y-auto flex-1 min-h-0 space-y-4 px-1.5 py-1">
                 {configTab === 'basic' && (
                   <div className="space-y-3">
                     {/* Mode toggle (dialog-specific: drives headless + keyboard shortcut) */}

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -11,6 +11,8 @@ import { Zap } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { TileToggleRow } from '@/components/ui/tile-toggle-row'
+import { TogglePill } from '@/components/ui/toggle-pill'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import { updateProjectSettings, useSessionsStore, wsSend } from '@/hooks/use-sessions'
 import { sendSpawnRequest } from '@/hooks/use-spawn'
@@ -520,52 +522,20 @@ export function SpawnDialog() {
                     />
 
                     {/* REPL tool toggle (dialog-specific) */}
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      className="flex items-center justify-between py-1.5 cursor-pointer select-none"
-                      onClick={() => {
-                        setRepl(!repl)
-                        haptic('tap')
-                      }}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          setRepl(!repl)
-                          haptic('tap')
-                        }
-                      }}
-                    >
-                      <div>
-                        <div className="text-sm font-mono">REPL tool</div>
-                        <div className="text-[10px] text-[#565f89]">
-                          JS sandbox for batched tool calls (CLAUDE_CODE_REPL)
-                        </div>
-                      </div>
-                      <ToggleSwitch on={repl} />
-                    </div>
+                    <TileToggleRow
+                      title="REPL tool"
+                      subtitle="JS sandbox for batched tool calls (CLAUDE_CODE_REPL)"
+                      checked={repl}
+                      onToggle={() => setRepl(!repl)}
+                    />
 
                     {/* Bare toggle (dialog-specific) */}
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      className="flex items-center justify-between py-1.5 cursor-pointer select-none"
-                      onClick={() => {
-                        setBare(!bare)
-                        haptic('tap')
-                      }}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          setBare(!bare)
-                          haptic('tap')
-                        }
-                      }}
-                    >
-                      <div>
-                        <div className="text-sm font-mono">Bare session</div>
-                        <div className="text-[10px] text-[#565f89]">Skip hooks, plugins, CLAUDE.md, auto-memory</div>
-                      </div>
-                      <ToggleSwitch on={bare} />
-                    </div>
+                    <TileToggleRow
+                      title="Bare session"
+                      subtitle="Skip hooks, plugins, CLAUDE.md, auto-memory"
+                      checked={bare}
+                      onToggle={() => setBare(!bare)}
+                    />
 
                     {/* Env vars (LaunchConfigFields renders textarea, errors below) */}
                     <LaunchConfigFields value={fieldsValue} onChange={applyFieldsPatch} show={{ env: true }} />
@@ -677,56 +647,5 @@ export function SpawnDialog() {
         </div>
       </DialogContent>
     </Dialog>
-  )
-}
-
-// ─── Sub-components ──────────────────────────────────────────────
-
-function TogglePill({
-  active,
-  onClick,
-  label,
-  small,
-  shortcut,
-}: {
-  active: boolean
-  onClick: () => void
-  label: string
-  small?: boolean
-  shortcut?: string
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'rounded font-mono transition-all duration-150 inline-flex items-center gap-1.5',
-        small ? 'px-2.5 py-1 text-[11px]' : 'px-4 py-1.5 text-sm',
-        active
-          ? 'bg-[#7aa2f7]/20 text-[#7aa2f7] border border-[#7aa2f7]/40'
-          : 'bg-transparent text-[#565f89] border border-border hover:text-foreground hover:border-foreground/30',
-      )}
-    >
-      {label}
-      {shortcut && <Kbd className="text-[10px]">{shortcut}</Kbd>}
-    </button>
-  )
-}
-
-function ToggleSwitch({ on }: { on: boolean }) {
-  return (
-    <div
-      className={cn(
-        'w-9 h-5 rounded-full transition-colors duration-150 relative shrink-0',
-        on ? 'bg-[#7aa2f7]' : 'bg-[#1a1b26] border border-border',
-      )}
-    >
-      <div
-        className={cn(
-          'absolute top-0.5 w-4 h-4 rounded-full transition-transform duration-150',
-          on ? 'translate-x-4 bg-white' : 'translate-x-0.5 bg-[#565f89]',
-        )}
-      />
-    </div>
   )
 }

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -5,6 +5,7 @@
  * Phase 2 (launching): Step-by-step progress via shared LaunchMonitor.
  */
 
+import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS } from '@shared/spawn-schema'
 import { Zap } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
@@ -25,35 +26,6 @@ interface SpawnDialogState {
   open: boolean
   options: SpawnDialogOptions | null
 }
-
-// Radix Select requires non-empty string values; map '' <-> DEFAULT_SENTINEL
-const DEFAULT_SENTINEL = '__default__'
-
-const MODEL_OPTIONS: Array<{ value: string; label: string; info: string }> = [
-  { value: DEFAULT_SENTINEL, label: 'Default', info: 'Use project / global default' },
-  { value: 'opus', label: 'Opus (latest)', info: 'Most capable, best for complex reasoning' },
-  { value: 'claude-opus-4-7', label: 'Opus 4.7', info: 'Opus 4.7 pinned (1M context)' },
-  { value: 'claude-opus-4-6', label: 'Opus 4.6', info: 'Opus 4.6 pinned (1M context)' },
-  { value: 'sonnet', label: 'Sonnet (latest)', info: 'Balanced speed and capability' },
-  { value: 'haiku', label: 'Haiku (latest)', info: 'Fastest, lowest cost' },
-]
-
-const EFFORT_OPTIONS: Array<{ value: string; label: string; info: string }> = [
-  { value: DEFAULT_SENTINEL, label: 'Default', info: 'Use project / global default' },
-  { value: 'low', label: 'Low', info: 'Minimal thinking budget' },
-  { value: 'medium', label: 'Medium', info: 'Moderate thinking' },
-  { value: 'high', label: 'High', info: 'Deep thinking (slower)' },
-  { value: 'xhigh', label: 'XHigh', info: 'Extended deep thinking' },
-  { value: 'max', label: 'Max', info: 'Maximum thinking budget' },
-]
-
-const PERMISSION_MODES = [
-  { value: '', label: 'Default' },
-  { value: 'plan', label: 'Plan' },
-  { value: 'acceptEdits', label: 'Accept Edits' },
-  { value: 'auto', label: 'Auto' },
-  { value: 'bypassPermissions', label: 'Bypass' },
-]
 
 /** Parse KEY=value lines into env record. Returns [env, errors]. */
 function parseEnvText(text: string): [Record<string, string> | null, string[]] {
@@ -599,18 +571,21 @@ export function SpawnDialog() {
                         Permission mode
                       </div>
                       <div className="flex gap-1.5 flex-wrap">
-                        {PERMISSION_MODES.map(opt => (
-                          <TogglePill
-                            key={opt.value}
-                            active={permissionMode === opt.value}
-                            onClick={() => {
-                              setPermissionMode(opt.value)
-                              haptic('tap')
-                            }}
-                            label={opt.label}
-                            small
-                          />
-                        ))}
+                        {PERMISSION_MODE_OPTIONS.map(opt => {
+                          const stored = opt.value === DEFAULT_SENTINEL ? '' : opt.value
+                          return (
+                            <TogglePill
+                              key={opt.value}
+                              active={permissionMode === stored}
+                              onClick={() => {
+                                setPermissionMode(stored)
+                                haptic('tap')
+                              }}
+                              label={opt.label}
+                              small
+                            />
+                          )
+                        })}
                       </div>
                     </div>
 

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -5,7 +5,13 @@
  * Phase 2 (launching): Step-by-step progress via shared LaunchMonitor.
  */
 
-import { DEFAULT_SENTINEL, EFFORT_OPTIONS, MODEL_OPTIONS, PERMISSION_MODE_OPTIONS } from '@shared/spawn-schema'
+import {
+  DEFAULT_SENTINEL,
+  EFFORT_OPTIONS,
+  MODEL_OPTIONS,
+  PERMISSION_MODE_OPTIONS,
+  type SpawnRequest,
+} from '@shared/spawn-schema'
 import { Zap } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
@@ -13,6 +19,7 @@ import { Kbd, KbdGroup } from '@/components/ui/kbd'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import { updateProjectSettings, useSessionsStore, wsSend } from '@/hooks/use-sessions'
+import { sendSpawnRequest } from '@/hooks/use-spawn'
 import { useKeyLayer } from '@/lib/key-layers'
 import { cn, haptic } from '@/lib/utils'
 import { LaunchErrorBanner, LaunchFooterActions, LaunchStepList } from './launch-monitor'
@@ -213,45 +220,36 @@ export function SpawnDialog() {
     setJobId(newJobId)
     progress.start([{ label: 'Sending spawn request', status: 'active', ts: Date.now() }])
 
-    try {
-      const res = await fetch('/api/spawn', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          cwd: state.options.cwd,
-          mkdir: state.options.mkdir || false,
-          headless,
-          bare: bare || undefined,
-          repl: repl || undefined,
-          name: name.trim() || undefined,
-          model: model || undefined,
-          effort: effort || undefined,
-          permissionMode: permissionMode || undefined,
-          autocompactPct: autocompactPct || undefined,
-          maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
-          worktree: useWorktree && worktreeName.trim() ? worktreeName.trim() : undefined,
-          env: parsedEnv || undefined,
-          jobId: newJobId,
-        }),
-      })
-      const data = await res.json()
-      if (data.success) {
-        haptic('success')
-        setWrapperId(data.wrapperId)
-        progress.setSteps(prev => [
-          ...prev.map(s =>
-            s.status === 'active'
-              ? { ...s, status: 'done' as const, detail: `wrapper=${data.wrapperId.slice(0, 8)}` }
-              : s,
-          ),
-          { label: 'Waiting for session...', status: 'active' as const, ts: Date.now() },
-        ])
-      } else {
-        progress.setError(data.error || 'Spawn failed')
-        haptic('error')
-      }
-    } catch (err: unknown) {
-      progress.setError(err instanceof Error ? err.message : 'Network error')
+    const spawnReq: SpawnRequest = {
+      cwd: state.options.cwd,
+      mkdir: state.options.mkdir || false,
+      headless,
+      bare: bare || undefined,
+      repl: repl || undefined,
+      name: name.trim() || undefined,
+      model: (model || undefined) as SpawnRequest['model'],
+      effort: (effort || undefined) as SpawnRequest['effort'],
+      permissionMode: (permissionMode || undefined) as SpawnRequest['permissionMode'],
+      autocompactPct: autocompactPct === '' ? undefined : autocompactPct,
+      maxBudgetUsd: maxBudgetUsd ? Number(maxBudgetUsd) : undefined,
+      worktree: useWorktree && worktreeName.trim() ? worktreeName.trim() : undefined,
+      env: parsedEnv || undefined,
+      jobId: newJobId,
+    }
+    const result = await sendSpawnRequest(spawnReq)
+    if (result.ok) {
+      haptic('success')
+      setWrapperId(result.wrapperId)
+      progress.setSteps(prev => [
+        ...prev.map(s =>
+          s.status === 'active'
+            ? { ...s, status: 'done' as const, detail: `wrapper=${result.wrapperId.slice(0, 8)}` }
+            : s,
+        ),
+        { label: 'Waiting for session...', status: 'active' as const, ts: Date.now() },
+      ])
+    } else {
+      progress.setError(result.error)
       haptic('error')
     }
   }, [

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -5,6 +5,7 @@
  * Phase 2 (launching): Step-by-step progress via shared LaunchMonitor.
  */
 
+import { buildSpawnDiagnostics } from '@shared/spawn-diagnostics'
 import {
   DEFAULT_SENTINEL,
   EFFORT_OPTIONS,
@@ -353,32 +354,39 @@ export function SpawnDialog() {
   }
 
   function handleCopyLog() {
-    const log = {
-      type: 'spawn_log',
-      time: new Date().toISOString(),
-      cwd: state.options?.cwd,
+    const [parsedEnv] = parseEnvText(envText)
+    const diag = buildSpawnDiagnostics({
+      source: 'spawn-dialog',
       jobId,
       wrapperId: wrapperId || progress.launch.wrapperId || null,
-      sessionId: progress.launch.sessionId || null,
-      elapsed: `${progress.elapsed}s`,
+      sessionId: progress.launch.sessionId ?? null,
+      elapsedSec: progress.elapsed,
       error: progress.error || progress.launch.error || null,
-      events: progress.launch.events.map(e => ({
-        status: e.status,
-        step: e.step,
-        detail: e.detail || null,
-        t: e.t,
-      })),
       config: {
+        cwd: state.options?.cwd,
         headless,
         bare,
-        name: name || null,
-        model: model || null,
-        effort: effort || null,
-        permissionMode: permissionMode || null,
-        env: envText.trim() || null,
+        name: name || undefined,
+        model: (model || undefined) as SpawnRequest['model'],
+        effort: (effort || undefined) as SpawnRequest['effort'],
+        permissionMode: (permissionMode || undefined) as SpawnRequest['permissionMode'],
+        env: parsedEnv ?? undefined,
       },
-    }
-    progress.copyToClipboard(JSON.stringify(log, null, 2))
+      steps: progress.steps.map(s => ({
+        label: s.label,
+        status: s.status,
+        detail: s.detail ?? null,
+        ts: s.ts ?? null,
+      })),
+      launchEvents: progress.launch.events.map(e => ({
+        step: e.step,
+        status: e.status,
+        detail: e.detail ?? null,
+        t: e.t,
+      })),
+      launchState: { completed: progress.launch.completed, failed: progress.launch.failed },
+    })
+    progress.copyToClipboard(JSON.stringify(diag, null, 2))
   }
 
   const shortPath = state.options?.cwd?.replace(/^\/Users\/[^/]+/, '~') || ''

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -103,6 +103,7 @@ export function SpawnDialog() {
   })
 
   // Register the open callback
+  const progressReset = progress.reset
   useEffect(() => {
     _openDialog = (options: SpawnDialogOptions) => {
       const ps = projectSettings[options.cwd]
@@ -131,12 +132,15 @@ export function SpawnDialog() {
       setPhase('config')
       setJobId(null)
       setWrapperId(null)
+      // Drop any stale error/steps from a prior failed launch so reopening
+      // the dialog doesn't show the old "Session failed to connect" banner.
+      progressReset()
       setState({ open: true, options })
     }
     return () => {
       _openDialog = null
     }
-  }, [projectSettings, globalSettings])
+  }, [projectSettings, globalSettings, progressReset])
 
   // Add "Session connected" step when session connects
   const addedConnectedStepRef = useRef(false)

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -259,13 +259,12 @@ export function SpawnDialog() {
     progress,
   ])
 
-  // Keyboard layer: ESC closes, Enter spawns (config) or views session (launching).
+  // Keyboard layer: Enter spawns (config) or views session (launching). Radix Dialog handles Escape.
   // Config-only quick toggles: h/p = Headless/PTY, 1/2 = Basic/Advanced tab.
   // Single-letter/digit bindings are auto-skipped when a text input is focused
   // (see useKeyLayer: `if (inTextInput && !isModified && !isNonPrintable) return`).
   useKeyLayer(
     {
-      Escape: handleClose,
       Enter: () => {
         if (phase === 'config') handleSpawn()
         else if (phase === 'launching' && progress.isConnected) handleViewSession()

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -16,6 +16,7 @@ import { TogglePill } from '@/components/ui/toggle-pill'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import { updateProjectSettings, useSessionsStore, wsSend } from '@/hooks/use-sessions'
 import { sendSpawnRequest } from '@/hooks/use-spawn'
+import { parseEnvText } from '@/lib/env-parse'
 import { useKeyLayer } from '@/lib/key-layers'
 import { cn, haptic } from '@/lib/utils'
 import { LaunchConfigFields, type LaunchFieldsValue } from './launch-config-fields'
@@ -29,34 +30,6 @@ export interface SpawnDialogOptions {
 interface SpawnDialogState {
   open: boolean
   options: SpawnDialogOptions | null
-}
-
-/** Parse KEY=value lines into env record. Returns [env, errors]. */
-function parseEnvText(text: string): [Record<string, string> | null, string[]] {
-  if (!text.trim()) return [null, []]
-  const env: Record<string, string> = {}
-  const errors: string[] = []
-  for (const [i, raw] of text.split('\n').entries()) {
-    const line = raw.trim()
-    if (!line || line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq < 1) {
-      errors.push(`Line ${i + 1}: missing KEY=value`)
-      continue
-    }
-    const key = line.slice(0, eq)
-    const value = line.slice(eq + 1)
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-      errors.push(`Line ${i + 1}: invalid key "${key}"`)
-      continue
-    }
-    if (/["']/.test(value)) {
-      errors.push(`Line ${i + 1}: no quotes needed, use raw value`)
-      continue
-    }
-    env[key] = value
-  }
-  return [errors.length ? null : Object.keys(env).length ? env : null, errors]
 }
 
 // Module-level state so any component can trigger the dialog
@@ -82,7 +55,6 @@ export function SpawnDialog() {
   const [maxBudgetUsd, setMaxBudgetUsd] = useState('')
   const [configTab, setConfigTab] = useState<'basic' | 'advanced'>('basic')
   const [envText, setEnvText] = useState('')
-  const [envErrors, setEnvErrors] = useState<string[]>([])
   const [phase, setPhase] = useState<'config' | 'launching'>('config')
   const [savedFeedback, setSavedFeedback] = useState<string | null>(null)
   const [jobId, setJobId] = useState<string | null>(null)
@@ -127,7 +99,6 @@ export function SpawnDialog() {
       const envDefault = ps?.defaultEnvText || (gs.defaultEnvText as string) || ''
       setEnvText(envDefault)
       setConfigTab('basic')
-      setEnvErrors([])
       setSavedFeedback(null)
       setPhase('config')
       setJobId(null)
@@ -197,10 +168,12 @@ export function SpawnDialog() {
   const handleSpawn = useCallback(async () => {
     if (!state.options || phase !== 'config') return
 
-    // Validate env before spawning
+    // Validate env before spawning. Errors render inline in LaunchConfigFields
+    // as the user types, so we just block submit here.
     const [parsedEnv, errors] = parseEnvText(envText)
     if (errors.length) {
-      setEnvErrors(errors)
+      setConfigTab('advanced')
+      haptic('error')
       return
     }
 
@@ -340,7 +313,6 @@ export function SpawnDialog() {
     setAutocompactPct('')
     setMaxBudgetUsd('')
     setEnvText('')
-    setEnvErrors([])
     haptic('tap')
   }
 
@@ -391,10 +363,7 @@ export function SpawnDialog() {
     if ('maxBudgetUsd' in patch) setMaxBudgetUsd(patch.maxBudgetUsd ?? '')
     if ('useWorktree' in patch) setUseWorktree(!!patch.useWorktree)
     if ('worktreeName' in patch) setWorktreeName(patch.worktreeName ?? '')
-    if ('envText' in patch) {
-      setEnvText(patch.envText ?? '')
-      setEnvErrors([])
-    }
+    if ('envText' in patch) setEnvText(patch.envText ?? '')
     if ('name' in patch) setName(patch.name ?? '')
   }
 
@@ -543,15 +512,8 @@ export function SpawnDialog() {
                       onToggle={() => setBare(!bare)}
                     />
 
-                    {/* Env vars (LaunchConfigFields renders textarea, errors below) */}
+                    {/* Env vars (LaunchConfigFields renders textarea + inline errors) */}
                     <LaunchConfigFields value={fieldsValue} onChange={applyFieldsPatch} show={{ env: true }} />
-                    {envErrors.length > 0 && (
-                      <div className="text-[10px] font-mono text-red-400 space-y-0.5">
-                        {envErrors.map(e => (
-                          <div key={e}>{e}</div>
-                        ))}
-                      </div>
-                    )}
                     <div className="text-[9px] text-[#565f89]">
                       KEY=value per line, set before executing claude. # comments ok.
                     </div>

--- a/web/src/components/spawn-dialog.tsx
+++ b/web/src/components/spawn-dialog.tsx
@@ -6,23 +6,17 @@
  */
 
 import { buildSpawnDiagnostics } from '@shared/spawn-diagnostics'
-import {
-  DEFAULT_SENTINEL,
-  EFFORT_OPTIONS,
-  MODEL_OPTIONS,
-  PERMISSION_MODE_OPTIONS,
-  type SpawnRequest,
-} from '@shared/spawn-schema'
+import type { SpawnRequest } from '@shared/spawn-schema'
 import { Zap } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useLaunchProgress } from '@/hooks/use-launch-progress'
 import { updateProjectSettings, useSessionsStore, wsSend } from '@/hooks/use-sessions'
 import { sendSpawnRequest } from '@/hooks/use-spawn'
 import { useKeyLayer } from '@/lib/key-layers'
 import { cn, haptic } from '@/lib/utils'
+import { LaunchConfigFields, type LaunchFieldsValue } from './launch-config-fields'
 import { LaunchErrorBanner, LaunchFooterActions, LaunchStepList } from './launch-monitor'
 
 export interface SpawnDialogOptions {
@@ -91,7 +85,6 @@ export function SpawnDialog() {
   const [savedFeedback, setSavedFeedback] = useState<string | null>(null)
   const [jobId, setJobId] = useState<string | null>(null)
   const [wrapperId, setWrapperId] = useState<string | null>(null)
-  const nameRef = useRef<HTMLInputElement>(null)
   // Track which session was selected when spawn started -- don't yank the user
   // back to the spawned session if they navigated away during the countdown
   const sessionAtSpawnRef = useRef<string | null>(null)
@@ -142,13 +135,6 @@ export function SpawnDialog() {
       _openDialog = null
     }
   }, [projectSettings, globalSettings])
-
-  // Focus name input when dialog opens in config phase
-  useEffect(() => {
-    if (state.open && phase === 'config') {
-      setTimeout(() => nameRef.current?.focus(), 100)
-    }
-  }, [state.open, phase])
 
   // Add "Session connected" step when session connects
   const addedConnectedStepRef = useRef(false)
@@ -390,10 +376,34 @@ export function SpawnDialog() {
   }
 
   const shortPath = state.options?.cwd?.replace(/^\/Users\/[^/]+/, '~') || ''
-  const projSettings = state.options ? projectSettings[state.options.cwd] : undefined
-  const defaultModel = projSettings?.defaultModel || (globalSettings.defaultModel as string) || 'opus'
-  const defaultEffort = projSettings?.defaultEffort || (globalSettings.defaultEffort as string) || 'default'
   const displayError = progress.error || progress.launch.error
+
+  function applyFieldsPatch(patch: Partial<LaunchFieldsValue>) {
+    if ('model' in patch) setModel(patch.model ?? '')
+    if ('effort' in patch) setEffort(patch.effort ?? '')
+    if ('permissionMode' in patch) setPermissionMode(patch.permissionMode ?? '')
+    if ('autocompactPct' in patch) setAutocompactPct(patch.autocompactPct ?? '')
+    if ('maxBudgetUsd' in patch) setMaxBudgetUsd(patch.maxBudgetUsd ?? '')
+    if ('useWorktree' in patch) setUseWorktree(!!patch.useWorktree)
+    if ('worktreeName' in patch) setWorktreeName(patch.worktreeName ?? '')
+    if ('envText' in patch) {
+      setEnvText(patch.envText ?? '')
+      setEnvErrors([])
+    }
+    if ('name' in patch) setName(patch.name ?? '')
+  }
+
+  const fieldsValue: LaunchFieldsValue = {
+    model,
+    effort,
+    permissionMode,
+    autocompactPct,
+    maxBudgetUsd,
+    useWorktree,
+    worktreeName,
+    envText,
+    name,
+  }
 
   return (
     <Dialog open={state.open} onOpenChange={open => !open && handleClose()}>
@@ -460,31 +470,8 @@ export function SpawnDialog() {
               {/* Scrollable content area */}
               <div className="overflow-y-auto flex-1 min-h-0 space-y-4 px-0.5">
                 {configTab === 'basic' && (
-                  <>
-                    {/* Name input */}
-                    <div className="space-y-1.5">
-                      <label
-                        htmlFor="spawn-name"
-                        className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5"
-                      >
-                        Name <span className="text-[#565f89]">(optional)</span>
-                      </label>
-                      <input
-                        ref={nameRef}
-                        id="spawn-name"
-                        type="text"
-                        value={name}
-                        onChange={e => setName(e.target.value)}
-                        placeholder="e.g. refactor-auth"
-                        className={cn(
-                          'w-full bg-[#1a1b26] border border-border rounded px-3 py-1.5',
-                          'text-sm font-mono text-foreground placeholder:text-[#565f89]',
-                          'focus:outline-none focus:border-[#7aa2f7]/50',
-                        )}
-                      />
-                    </div>
-
-                    {/* Mode toggle */}
+                  <div className="space-y-3">
+                    {/* Mode toggle (dialog-specific: drives headless + keyboard shortcut) */}
                     <div className="space-y-2">
                       <div className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5">
                         Mode
@@ -511,207 +498,28 @@ export function SpawnDialog() {
                       </div>
                     </div>
 
-                    {/* Model selector */}
-                    <div className="space-y-1.5">
-                      <label
-                        htmlFor="spawn-model"
-                        className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5"
-                      >
-                        Model
-                      </label>
-                      <Select
-                        value={model === '' ? DEFAULT_SENTINEL : model}
-                        onValueChange={v => {
-                          setModel(v === DEFAULT_SENTINEL ? '' : v)
-                          haptic('tap')
-                        }}
-                      >
-                        <SelectTrigger id="spawn-model" className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {MODEL_OPTIONS.map(opt => (
-                            <SelectItem key={opt.value} value={opt.value} info={opt.info}>
-                              {opt.value === DEFAULT_SENTINEL ? `Default (${defaultModel})` : opt.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    {/* Effort selector */}
-                    <div className="space-y-1.5">
-                      <label
-                        htmlFor="spawn-effort"
-                        className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5"
-                      >
-                        Effort
-                      </label>
-                      <Select
-                        value={effort === '' ? DEFAULT_SENTINEL : effort}
-                        onValueChange={v => {
-                          setEffort(v === DEFAULT_SENTINEL ? '' : v)
-                          haptic('tap')
-                        }}
-                      >
-                        <SelectTrigger id="spawn-effort" className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {EFFORT_OPTIONS.map(opt => (
-                            <SelectItem key={opt.value} value={opt.value} info={opt.info}>
-                              {opt.value === DEFAULT_SENTINEL ? `Default (${defaultEffort})` : opt.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </>
+                    <LaunchConfigFields
+                      value={fieldsValue}
+                      onChange={applyFieldsPatch}
+                      show={{ name: true, model: true, effort: true }}
+                    />
+                  </div>
                 )}
 
                 {configTab === 'advanced' && (
                   <div className="space-y-3">
-                    {/* Permission mode */}
-                    <div className="space-y-2">
-                      <div className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5">
-                        Permission mode
-                      </div>
-                      <div className="flex gap-1.5 flex-wrap">
-                        {PERMISSION_MODE_OPTIONS.map(opt => {
-                          const stored = opt.value === DEFAULT_SENTINEL ? '' : opt.value
-                          return (
-                            <TogglePill
-                              key={opt.value}
-                              active={permissionMode === stored}
-                              onClick={() => {
-                                setPermissionMode(stored)
-                                haptic('tap')
-                              }}
-                              label={opt.label}
-                              small
-                            />
-                          )
-                        })}
-                      </div>
-                    </div>
+                    <LaunchConfigFields
+                      value={fieldsValue}
+                      onChange={applyFieldsPatch}
+                      show={{
+                        permissionMode: true,
+                        autocompactPct: true,
+                        maxBudgetUsd: headless,
+                        worktree: true,
+                      }}
+                    />
 
-                    {/* Autocompact threshold */}
-                    <div className="space-y-2">
-                      <div className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5">
-                        Autocompact threshold
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <input
-                          type="range"
-                          min={50}
-                          max={99}
-                          value={autocompactPct || 83}
-                          onChange={e => {
-                            setAutocompactPct(Number(e.target.value))
-                            haptic('tick')
-                          }}
-                          className="flex-1 h-1.5 accent-[#7aa2f7] bg-muted rounded-full"
-                        />
-                        <span
-                          className={cn(
-                            'text-sm font-mono w-12 text-right tabular-nums',
-                            autocompactPct ? 'text-[#7aa2f7]' : 'text-[#565f89]',
-                          )}
-                        >
-                          {autocompactPct || 83}%
-                        </span>
-                        {autocompactPct && (
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setAutocompactPct('')
-                              haptic('tap')
-                            }}
-                            className="text-[10px] text-[#565f89] hover:text-foreground font-mono"
-                          >
-                            reset
-                          </button>
-                        )}
-                      </div>
-                      <div className="text-[9px] text-[#565f89]">Context % that triggers compaction (default ~83%)</div>
-                    </div>
-
-                    {/* Max budget (headless only) */}
-                    {headless && (
-                      <div className="space-y-2">
-                        <div className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5">
-                          Max budget (USD)
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-[#565f89] text-sm">$</span>
-                          <input
-                            type="number"
-                            min={0.01}
-                            step={0.01}
-                            placeholder="no limit"
-                            value={maxBudgetUsd}
-                            onChange={e => setMaxBudgetUsd(e.target.value)}
-                            className="w-24 bg-[#1a1b26] border border-[#292e42] rounded px-2 py-1 text-sm font-mono text-foreground focus:outline-none focus:border-[#7aa2f7] [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                          />
-                          {maxBudgetUsd && (
-                            <button
-                              type="button"
-                              onClick={() => setMaxBudgetUsd('')}
-                              className="text-[10px] text-[#565f89] hover:text-foreground font-mono"
-                            >
-                              clear
-                            </button>
-                          )}
-                        </div>
-                        <div className="text-[9px] text-[#565f89]">
-                          Stop session after spending this amount (--max-budget-usd, headless only)
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Worktree toggle */}
-                    <div className="space-y-1.5">
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        className="flex items-center justify-between py-1.5 cursor-pointer select-none"
-                        onClick={() => {
-                          const next = !useWorktree
-                          setUseWorktree(next)
-                          if (next && !worktreeName) setWorktreeName(name.trim() || '')
-                          haptic('tap')
-                        }}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            const next = !useWorktree
-                            setUseWorktree(next)
-                            if (next && !worktreeName) setWorktreeName(name.trim() || '')
-                            haptic('tap')
-                          }
-                        }}
-                      >
-                        <div>
-                          <div className="text-sm font-mono">Git worktree</div>
-                          <div className="text-[10px] text-[#565f89]">Isolated branch, auto-merges on completion</div>
-                        </div>
-                        <ToggleSwitch on={useWorktree} />
-                      </div>
-                      {useWorktree && (
-                        <input
-                          type="text"
-                          value={worktreeName}
-                          onChange={e => setWorktreeName(e.target.value)}
-                          placeholder="Branch name..."
-                          className={cn(
-                            'w-full bg-[#1a1b26] border border-border rounded px-3 py-1.5',
-                            'text-sm font-mono text-foreground placeholder:text-[#565f89]',
-                            'focus:outline-none focus:border-[#7aa2f7]/50',
-                          )}
-                        />
-                      )}
-                    </div>
-
-                    {/* REPL tool toggle */}
+                    {/* REPL tool toggle (dialog-specific) */}
                     <div
                       role="button"
                       tabIndex={0}
@@ -736,7 +544,7 @@ export function SpawnDialog() {
                       <ToggleSwitch on={repl} />
                     </div>
 
-                    {/* Bare toggle */}
+                    {/* Bare toggle (dialog-specific) */}
                     <div
                       role="button"
                       tabIndex={0}
@@ -759,39 +567,17 @@ export function SpawnDialog() {
                       <ToggleSwitch on={bare} />
                     </div>
 
-                    {/* Custom env vars */}
-                    <div className="space-y-1.5">
-                      <div className="text-[11px] font-mono text-muted-foreground uppercase tracking-wide pl-0.5">
-                        Environment variables
+                    {/* Env vars (LaunchConfigFields renders textarea, errors below) */}
+                    <LaunchConfigFields value={fieldsValue} onChange={applyFieldsPatch} show={{ env: true }} />
+                    {envErrors.length > 0 && (
+                      <div className="text-[10px] font-mono text-red-400 space-y-0.5">
+                        {envErrors.map(e => (
+                          <div key={e}>{e}</div>
+                        ))}
                       </div>
-                      <textarea
-                        value={envText}
-                        onChange={e => {
-                          setEnvText(e.target.value)
-                          setEnvErrors([])
-                        }}
-                        placeholder={'MAX_THINKING_TOKENS=16000\nCLAUDE_CODE_EFFORT_LEVEL=max'}
-                        rows={3}
-                        spellCheck={false}
-                        className={cn(
-                          'w-full bg-[#1a1b26] border rounded px-3 py-2',
-                          'text-xs font-mono text-foreground placeholder:text-[#565f89]/60',
-                          'focus:outline-none resize-y leading-relaxed',
-                          envErrors.length
-                            ? 'border-red-500/60 focus:border-red-500'
-                            : 'border-border focus:border-[#7aa2f7]/50',
-                        )}
-                      />
-                      {envErrors.length > 0 && (
-                        <div className="text-[10px] font-mono text-red-400 space-y-0.5">
-                          {envErrors.map(e => (
-                            <div key={e}>{e}</div>
-                          ))}
-                        </div>
-                      )}
-                      <div className="text-[9px] text-[#565f89]">
-                        KEY=value per line, set before executing claude. # comments ok.
-                      </div>
+                    )}
+                    <div className="text-[9px] text-[#565f89]">
+                      KEY=value per line, set before executing claude. # comments ok.
                     </div>
 
                     {/* Save / Reset defaults */}

--- a/web/src/components/task-batch-selector.tsx
+++ b/web/src/components/task-batch-selector.tsx
@@ -14,6 +14,7 @@
 import { Fzf } from 'fzf'
 import { CheckSquare, Copy, ListChecks, Search, Send, X } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Kbd } from '@/components/ui/kbd'
 import type { ProjectTaskMeta, TaskStatus } from '@/hooks/use-project'
 import { useProject } from '@/hooks/use-project'
@@ -341,41 +342,27 @@ export const TaskBatchSelector = memo(function TaskBatchSelector() {
     setOpen(false)
   }
 
-  // Keyboard layer: ESC to close, Enter to submit (when not in textarea)
+  // Radix handles Escape natively; we keep mod+Enter for submit inside the dialog.
   useKeyLayer(
     {
-      Escape: handleClose,
       'mod+Enter': () => handleSubmit(),
     },
     { id: 'batch-selector', enabled: open },
   )
 
-  if (!open) return null
-
   const hasActiveSession = !!selectedSessionId && sessions.some(s => s.id === selectedSessionId && s.status !== 'ended')
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-
-      {/* Modal */}
-      <div className="relative w-full max-w-lg max-h-[85vh] flex flex-col bg-[#1a1b26] border border-[#33467c]/60 rounded-lg shadow-2xl overflow-hidden">
+    <Dialog open={open} onOpenChange={v => !v && handleClose()}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col overflow-hidden rounded-lg p-0">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
           <div className="flex items-center gap-2">
             <ListChecks className="w-4 h-4 text-accent" />
-            <span className="text-sm font-bold font-mono text-foreground">Select Tasks</span>
+            <DialogTitle className="text-sm">Select Tasks</DialogTitle>
           </div>
           <div className="flex items-center gap-2">
             <Kbd className="text-[9px]">Esc</Kbd>
-            <button
-              type="button"
-              onClick={handleClose}
-              className="p-1 text-muted-foreground/60 hover:text-foreground transition-colors"
-            >
-              <X className="w-4 h-4" />
-            </button>
           </div>
         </div>
 
@@ -612,7 +599,7 @@ export const TaskBatchSelector = memo(function TaskBatchSelector() {
             </button>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 })

--- a/web/src/components/ui/tile-toggle-row.tsx
+++ b/web/src/components/ui/tile-toggle-row.tsx
@@ -1,0 +1,67 @@
+/**
+ * TileToggleRow - Keyboard-activable row tile wrapping a ToggleSwitch.
+ *
+ * role=button + tabIndex=0 + Enter/Space onKeyDown makes the whole row a
+ * keyboard-navigable target. Pair with the existing base useKeyLayer gate --
+ * single-letter shortcuts still skip when text input is focused.
+ */
+
+import type React from 'react'
+import { ToggleSwitch } from '@/components/ui/toggle-switch'
+import { cn, haptic } from '@/lib/utils'
+
+export interface TileToggleRowProps {
+  title: string
+  subtitle?: string
+  checked: boolean
+  onToggle: () => void
+  disabled?: boolean
+  'aria-label'?: string
+}
+
+export function TileToggleRow({
+  title,
+  subtitle,
+  checked,
+  onToggle,
+  disabled,
+  'aria-label': ariaLabel,
+}: TileToggleRowProps) {
+  function handleToggle() {
+    if (disabled) return
+    onToggle()
+    haptic('tap')
+  }
+
+  function handleKey(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleToggle()
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={ariaLabel || title}
+      aria-pressed={checked}
+      aria-disabled={disabled || undefined}
+      className={cn(
+        'flex items-center justify-between py-1.5 px-1 rounded cursor-pointer select-none',
+        'focus:outline-none focus:ring-1 focus:ring-[#7aa2f7]/50',
+        disabled && 'opacity-50 cursor-not-allowed',
+      )}
+      onClick={handleToggle}
+      onKeyDown={handleKey}
+    >
+      <div>
+        <div className="text-sm font-mono">{title}</div>
+        {subtitle && <div className="text-[10px] text-[#565f89]">{subtitle}</div>}
+      </div>
+      <ToggleSwitch on={checked} />
+    </div>
+  )
+}
+
+export default TileToggleRow

--- a/web/src/components/ui/toggle-pill.tsx
+++ b/web/src/components/ui/toggle-pill.tsx
@@ -1,0 +1,43 @@
+/**
+ * TogglePill - Segmented-style pill button. Render a row of these for a
+ * segmented control (Mode = Headless / PTY, Permissions = Plan / Accept / ...).
+ *
+ * Single-button API: `active` + `onClick`. Parent decides selection logic so
+ * the component stays dumb.
+ */
+
+import { Kbd } from '@/components/ui/kbd'
+import { cn } from '@/lib/utils'
+
+export interface TogglePillProps {
+  active: boolean
+  onClick: () => void
+  label: string
+  small?: boolean
+  shortcut?: string
+  title?: string
+}
+
+export function TogglePill({ active, onClick, label, small, shortcut, title }: TogglePillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={cn(
+        'rounded font-mono transition-all duration-150 inline-flex items-center gap-1.5',
+        small ? 'px-2.5 py-1 text-[11px]' : 'px-4 py-1.5 text-sm',
+        'focus:outline-none focus:ring-1 focus:ring-[#7aa2f7]/50',
+        active
+          ? 'bg-[#7aa2f7]/20 text-[#7aa2f7] border border-[#7aa2f7]/40'
+          : 'bg-transparent text-[#565f89] border border-border hover:text-foreground hover:border-foreground/30',
+      )}
+    >
+      {label}
+      {shortcut && <Kbd className="text-[10px]">{shortcut}</Kbd>}
+    </button>
+  )
+}
+
+export default TogglePill

--- a/web/src/components/ui/toggle-switch.tsx
+++ b/web/src/components/ui/toggle-switch.tsx
@@ -1,0 +1,27 @@
+/**
+ * ToggleSwitch - Animated on/off pill. Display-only; parent owns state.
+ *
+ * Pair with <TileToggleRow> (or your own row) for keyboard-activable toggles.
+ */
+
+import { cn } from '@/lib/utils'
+
+export function ToggleSwitch({ on }: { on: boolean }) {
+  return (
+    <div
+      className={cn(
+        'w-9 h-5 rounded-full transition-colors duration-150 relative shrink-0',
+        on ? 'bg-[#7aa2f7]' : 'bg-[#1a1b26] border border-border',
+      )}
+    >
+      <div
+        className={cn(
+          'absolute top-0.5 w-4 h-4 rounded-full transition-transform duration-150',
+          on ? 'translate-x-4 bg-white' : 'translate-x-0.5 bg-[#565f89]',
+        )}
+      />
+    </div>
+  )
+}
+
+export default ToggleSwitch

--- a/web/src/hooks/use-launch-channel.ts
+++ b/web/src/hooks/use-launch-channel.ts
@@ -86,6 +86,26 @@ export function useLaunchChannel(jobId: string | null): LaunchChannelState {
           }))
           break
 
+        case 'launch_progress': {
+          const uiStatus: LaunchEvent['status'] =
+            detail.status === 'done' ? 'ok' : detail.status === 'error' ? 'error' : 'info'
+          setState(prev => ({
+            ...prev,
+            events: [
+              ...prev.events,
+              {
+                step: detail.step,
+                status: uiStatus,
+                detail: detail.detail,
+                t: detail.t || Date.now(),
+              },
+            ],
+            wrapperId: detail.wrapperId || prev.wrapperId,
+            sessionId: detail.sessionId || prev.sessionId,
+          }))
+          break
+        }
+
         case 'job_complete':
           setState(prev => ({
             ...prev,

--- a/web/src/hooks/use-launch-progress.ts
+++ b/web/src/hooks/use-launch-progress.ts
@@ -69,6 +69,19 @@ export function useLaunchProgress({
     connectedRef.current = false
   }
 
+  /** Clear all progress state without starting a new run. Call when re-entering
+   *  a host UI (e.g. reopening a dialog) to drop stale error/steps from a
+   *  previous launch. */
+  function reset() {
+    setSteps([])
+    setError(null)
+    setStartTime(0)
+    setElapsed(0)
+    setCopied(false)
+    setViewCountdown(null)
+    connectedRef.current = false
+  }
+
   // Track spawned session by wrapperId
   const spawnedSession: Session | null = useSessionsStore(
     useCallback(
@@ -200,6 +213,7 @@ export function useLaunchProgress({
     startTime,
     // Mutations
     start,
+    reset,
     setSteps,
     setError,
     setViewCountdown,

--- a/web/src/hooks/use-spawn.ts
+++ b/web/src/hooks/use-spawn.ts
@@ -1,0 +1,61 @@
+/**
+ * Dashboard spawn helper -- sends `spawn_request` over the WebSocket and
+ * awaits the matching `spawn_request_ack`. jobId correlates the request
+ * with the ack AND the per-launch progress events (`launch_log`, `job_complete`,
+ * `job_failed`) broadcast on the same socket.
+ */
+
+import type { SpawnRequestAck } from '@shared/protocol'
+import type { SpawnRequest } from '@shared/spawn-schema'
+import { wsSend } from './use-sessions'
+
+export type SpawnAckResult =
+  | { ok: true; wrapperId: string; jobId: string; tmuxSession?: string }
+  | { ok: false; error: string }
+
+// Module-level pending ack registry (jobId -> resolver).
+// Populated by sendSpawnRequest, drained by handleSpawnRequestAck (from use-websocket).
+const pendingAcks = new Map<string, (ack: SpawnRequestAck) => void>()
+
+/**
+ * Called from the WS message loop when a spawn_request_ack arrives.
+ * Resolves the pending promise for the matching jobId (if any).
+ */
+export function handleSpawnRequestAck(ack: SpawnRequestAck): void {
+  if (!ack.jobId) return
+  const resolver = pendingAcks.get(ack.jobId)
+  if (!resolver) return
+  pendingAcks.delete(ack.jobId)
+  resolver(ack)
+}
+
+/**
+ * Send a spawn request and wait for the server ack. Throws via resolve() the
+ * error path if the ack times out or the WS is not connected.
+ */
+export function sendSpawnRequest(req: SpawnRequest, timeoutMs = 15000): Promise<SpawnAckResult> {
+  return new Promise(resolve => {
+    const jobId = req.jobId ?? crypto.randomUUID()
+
+    const timer = globalThis.setTimeout(() => {
+      pendingAcks.delete(jobId)
+      resolve({ ok: false, error: 'Spawn request timed out' })
+    }, timeoutMs)
+
+    pendingAcks.set(jobId, ack => {
+      globalThis.clearTimeout(timer)
+      if (ack.ok && ack.wrapperId) {
+        resolve({ ok: true, wrapperId: ack.wrapperId, jobId, tmuxSession: ack.tmuxSession })
+      } else {
+        resolve({ ok: false, error: ack.error || 'Spawn failed' })
+      }
+    })
+
+    const sent = wsSend('spawn_request', { ...req, jobId })
+    if (!sent) {
+      pendingAcks.delete(jobId)
+      globalThis.clearTimeout(timer)
+      resolve({ ok: false, error: 'WebSocket not connected' })
+    }
+  })
+}

--- a/web/src/hooks/use-websocket.ts
+++ b/web/src/hooks/use-websocket.ts
@@ -777,6 +777,7 @@ function processMessage(msg: DashboardMessage) {
 
     // ─── Launch Job Events ──────────────────────────────────────────
     case 'launch_log':
+    case 'launch_progress':
     case 'job_complete':
     case 'job_failed': {
       window.dispatchEvent(new CustomEvent('launch-job-event', { detail: msg }))

--- a/web/src/hooks/use-websocket.ts
+++ b/web/src/hooks/use-websocket.ts
@@ -24,6 +24,7 @@ import {
   type ProjectSettingsMap,
   useSessionsStore,
 } from './use-sessions'
+import { handleSpawnRequestAck } from './use-spawn'
 import { recordIn, recordOut } from './ws-stats'
 
 // Dashboard message from concentrator WS (loose type field for extensibility)
@@ -779,6 +780,21 @@ function processMessage(msg: DashboardMessage) {
     case 'job_complete':
     case 'job_failed': {
       window.dispatchEvent(new CustomEvent('launch-job-event', { detail: msg }))
+      break
+    }
+
+    // ─── Spawn Request Ack (WS spawn_request → ack by jobId) ────────
+    case 'spawn_request_ack': {
+      handleSpawnRequestAck(
+        msg as unknown as {
+          type: 'spawn_request_ack'
+          ok: boolean
+          jobId?: string
+          wrapperId?: string
+          tmuxSession?: string
+          error?: string
+        },
+      )
       break
     }
   }

--- a/web/src/lib/env-parse.ts
+++ b/web/src/lib/env-parse.ts
@@ -1,0 +1,35 @@
+/**
+ * parseEnvText - Parse a KEY=value-per-line env block into a record.
+ * Returns [env, errors]. env is null when there are errors, OR when the
+ * trimmed input is empty (so callers can treat "no env set" the same as
+ * "no env parsed"). Errors are 1-indexed by line.
+ *
+ * Shared between SpawnDialog (used at submit time) and LaunchConfigFields
+ * (used inline, every keystroke, for live error display).
+ */
+export function parseEnvText(text: string): [Record<string, string> | null, string[]] {
+  if (!text.trim()) return [null, []]
+  const env: Record<string, string> = {}
+  const errors: string[] = []
+  for (const [i, raw] of text.split('\n').entries()) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq < 1) {
+      errors.push(`Line ${i + 1}: missing KEY=value`)
+      continue
+    }
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      errors.push(`Line ${i + 1}: invalid key "${key}"`)
+      continue
+    }
+    if (/["']/.test(value)) {
+      errors.push(`Line ${i + 1}: no quotes needed, use raw value`)
+      continue
+    }
+    env[key] = value
+  }
+  return [errors.length ? null : Object.keys(env).length ? env : null, errors]
+}

--- a/web/src/lib/task-scoring.ts
+++ b/web/src/lib/task-scoring.ts
@@ -1,32 +1,8 @@
 import { Fzf } from 'fzf'
 import type { ProjectTaskMeta } from '@/hooks/use-project'
 
-/** Build the <project-task> prompt sent to CC when "Work on this" / /workon is used. */
-export function buildTaskPrompt(
-  task: {
-    slug: string
-    title: string
-    status: string
-    priority?: string
-    tags: string[]
-    bodyPreview?: string
-    body?: string
-  },
-  extraInstructions?: string,
-): string {
-  const tagAttrs = [
-    `id="${task.slug}"`,
-    `title="${task.title.replace(/"/g, '&quot;')}"`,
-    task.priority && task.priority !== 'medium' ? `priority="${task.priority}"` : '',
-    `status="${task.status}"`,
-    task.tags.length ? `tags="${task.tags.join(',')}"` : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-  const content = (task.body ?? task.bodyPreview ?? task.title).trim() || task.title
-  const instructions = `Set status to in-progress when you start, in-review when complete. Use mcp__rclaude__project_set_status with id="${task.slug}".`
-  return `<project-task ${tagAttrs}>\n${content}\n\n${instructions}${extraInstructions || ''}\n</project-task>`
-}
+/** Build the <project-task> prompt sent to CC. Re-exported from shared for single-source consistency. */
+export { buildTaskPrompt, type TaskMeta } from '@shared/spawn-prompt'
 
 export function statusBoost(status: string): number {
   return status === 'in-progress' ? 1.5 : status === 'open' ? 1.3 : 1


### PR DESCRIPTION
## Summary

Closes the spawn-unification epic (tickets 1-6 + epic, all in-review) and works through the follow-up punch list captured in `spawn-unify-followups.md`.

### Epic (landed earlier this week)

1. unified spawn request schema
2. `composeSpawnPrompt` + `resolveSpawnConfig` extracted
3. dispatch over WebSocket, HTTP route as thin wrapper
4. unified permissions / diagnostics / naming helpers
5. `launch_progress` promoted to first-class protocol event
6. `<LaunchConfigFields/>` extracted, used by SpawnDialog + RunTaskDialog

### Follow-ups (today)

- **MCP `get_spawn_diagnostics` tool** -- LaunchJob now accumulates events / config / completed|failed / sessionId. New WS handler + MCP tool return the full spawn trail so Claude can self-debug a flakey spawn (5-min retention).
- **MCP progress via `notifications/progress`** -- `spawn_session` accepts a progressToken. Wrapper subscribes to its own jobId before dispatching `channel_spawn` and forwards launch_progress events as 0-100% progress notifications. Returned payload now includes jobId + wrapperId so clients can follow up with `get_spawn_diagnostics`.
- **Advanced tab polish** -- autocompactPct is a range slider with live % readout + clear button; env textarea validates inline on every keystroke with red border + per-line errors (parser extracted to `web/src/lib/env-parse.ts`).
- **Radix Dialog consistency** -- converted shortcut-help, nerd-modal, quick-task, task-batch-selector, and project-board task editor to `<Dialog>`. Fixes Select/dropdown z-index bugs inside those modals. Command palette left untouched (virtualized cmdk, its own focus model).
- **Two bug fixes** caught during manual QA: stale error banner persisting when the spawn dialog is reopened after a 60s timeout, and input focus rings getting clipped by the scroll container's implicit overflow-x.

## Test plan

- [ ] Spawn a session from the dashboard; verify launch progress animates and the dialog auto-closes on connect.
- [ ] Reopen the spawn dialog after a forced 60s timeout -- no stale "Session failed to connect" banner.
- [ ] Tab into each Basic/Advanced input -- blue focus ring is fully visible (no right/bottom clip).
- [ ] Advanced tab: drag the autocompact slider; verify the % readout and the clear button.
- [ ] Advanced tab: paste `FOO=1\nBAR BAD KEY=2\nBAZ="quoted"` into the env box; verify inline red errors appear per line and submit is blocked until clean.
- [ ] From an MCP session with a progressToken, call `spawn_session` and confirm progress notifications arrive with step messages and 0-100% progress.
- [ ] From an MCP session, call `get_spawn_diagnostics` with a known-failed jobId and confirm the event timeline + config come back as JSON.
- [ ] Open the Details-for-Nerds panel, Shift+? help, quick-task (Ctrl+Shift+N), and the task-batch selector -- all open/close via Radix with consistent overlay/blur.
- [ ] Open the project-board task editor, tab through the status/priority dropdowns -- no z-index clipping.