### PR TITLE
fix: seed contextMode from launch config model to survive assistant overwrites

### DIFF
--- a/src/concentrator/handlers/boot-lifecycle.ts
+++ b/src/concentrator/handlers/boot-lifecycle.ts
@@ -8,6 +8,7 @@
  * real one.
  */
 
+import { contextModeFromModel } from '../../shared/context-window'
 import type { BootStep, TranscriptBootEntry, WrapperCapability } from '../../shared/protocol'
 import type { MessageHandler } from '../handler-context'
 import { registerHandlers } from '../message-router'
@@ -34,13 +35,21 @@ const wrapperBoot: MessageHandler = (ctx, data) => {
   if (existing) {
     existing.status = 'booting'
     existing.lastActivity = Date.now()
-    if (pendingLaunchConfig && !existing.launchConfig) existing.launchConfig = pendingLaunchConfig
+    if (pendingLaunchConfig && !existing.launchConfig) {
+      existing.launchConfig = pendingLaunchConfig
+      if (!existing.contextMode) {
+        existing.contextMode = contextModeFromModel(pendingLaunchConfig.model)
+      }
+    }
   } else {
     // Create a placeholder session keyed by wrapperId -- the real sessionId
     // replaces this once session_promote arrives.
     const placeholder = ctx.sessions.createSession(wrapperId, cwd, undefined, claudeArgs, capabilities)
     placeholder.status = 'booting'
-    if (pendingLaunchConfig) placeholder.launchConfig = pendingLaunchConfig
+    if (pendingLaunchConfig) {
+      placeholder.launchConfig = pendingLaunchConfig
+      placeholder.contextMode = contextModeFromModel(pendingLaunchConfig.model)
+    }
     if (data.claudeVersion) placeholder.claudeVersion = data.claudeVersion as string
     if (data.claudeAuth) placeholder.claudeAuth = data.claudeAuth as Record<string, unknown>
     if (data.title) placeholder.title = data.title as string

--- a/src/concentrator/handlers/session-lifecycle.ts
+++ b/src/concentrator/handlers/session-lifecycle.ts
@@ -3,6 +3,7 @@
  * heartbeat, session clear (re-key), notify, and end.
  */
 
+import { contextModeFromModel } from '../../shared/context-window'
 import { slugify } from '../address-book'
 import type { MessageHandler } from '../handler-context'
 import { registerHandlers } from '../message-router'
@@ -32,7 +33,14 @@ const meta: MessageHandler = (ctx, data) => {
     if (data.adHocTaskId) existingSession.adHocTaskId = data.adHocTaskId as string
     if (data.adHocWorktree) existingSession.adHocWorktree = data.adHocWorktree as string
     // Only set launchConfig on first connect (spawn), don't overwrite on revive
-    if (pendingLaunchConfig && !existingSession.launchConfig) existingSession.launchConfig = pendingLaunchConfig
+    if (pendingLaunchConfig && !existingSession.launchConfig) {
+      existingSession.launchConfig = pendingLaunchConfig
+      // Seed context mode from launch model (e.g. claude-opus-4-6[1m]) before
+      // assistant responses overwrite session.model with the bare API name
+      if (!existingSession.contextMode) {
+        existingSession.contextMode = contextModeFromModel(pendingLaunchConfig.model)
+      }
+    }
     ctx.log.debug(
       `Session resumed: ${sessionId.slice(0, 8)}... wrapper=${wrapperId.slice(0, 8)} (${data.cwd}) [${ctx.sessions.getActiveWrapperCount(sessionId) + 1} wrapper(s)]${data.version ? ` [${data.version}]` : ''}`,
     )
@@ -52,7 +60,12 @@ const meta: MessageHandler = (ctx, data) => {
     if (data.maxBudgetUsd) newSession.maxBudgetUsd = data.maxBudgetUsd as number
     if (data.adHocTaskId) newSession.adHocTaskId = data.adHocTaskId as string
     if (data.adHocWorktree) newSession.adHocWorktree = data.adHocWorktree as string
-    if (pendingLaunchConfig) newSession.launchConfig = pendingLaunchConfig
+    if (pendingLaunchConfig) {
+      newSession.launchConfig = pendingLaunchConfig
+      // Seed context mode from launch model (e.g. claude-opus-4-6[1m]) before
+      // assistant responses overwrite session.model with the bare API name
+      newSession.contextMode = contextModeFromModel(pendingLaunchConfig.model)
+    }
     const isAdHoc = (data.capabilities as string[] | undefined)?.includes('ad-hoc')
     ctx.log.debug(
       `Session started: ${sessionId.slice(0, 8)}... wrapper=${wrapperId.slice(0, 8)} (${data.cwd})${data.version ? ` [${data.version}]` : ''}`,

--- a/src/concentrator/session-store.ts
+++ b/src/concentrator/session-store.ts
@@ -7,7 +7,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'no
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { ServerWebSocket } from 'bun'
-import { resolveContextWindow } from '../shared/context-window'
+import { contextModeFromModel, resolveContextWindow } from '../shared/context-window'
 import type {
   ChannelStats,
   HookEvent,
@@ -1418,6 +1418,12 @@ export function createSessionStore(options: SessionStoreOptions = {}): SessionSt
         }
         if (data.model && typeof data.model === 'string' && !session.model) {
           session.model = data.model
+          // Seed context mode from init model suffix (e.g. claude-opus-4-6[1m])
+          // before assistant responses overwrite session.model with bare API name
+          if (!session.contextMode) {
+            const initMode = contextModeFromModel(data.model)
+            if (initMode) session.contextMode = initMode
+          }
         }
         // Clear stale error from previous run (belt and suspenders with resumeSession)
         session.lastError = undefined

--- a/src/shared/context-window.ts
+++ b/src/shared/context-window.ts
@@ -16,6 +16,15 @@ export function resolveContextWindow(model: string | undefined, contextMode?: '1
   return 200_000
 }
 
+/** Derive context mode from a model string (e.g. launch config model).
+ * Returns '1m' if the model has a 1M variant suffix or is a default-1M model. */
+export function contextModeFromModel(model: string | undefined): '1m' | undefined {
+  if (!model) return undefined
+  if (/(-1m|\[1m\])/i.test(model)) return '1m'
+  if (isDefault1MModel(model)) return '1m'
+  return undefined
+}
+
 /** Models whose 1M context window is the DEFAULT, not an opt-in variant. */
 function isDefault1MModel(model: string): boolean {
   // Opus 4.7 ships with 1M context by default. Older Opus/Sonnet/Haiku 4.x


### PR DESCRIPTION
## Summary

- Fixes context window showing 200K instead of 1M for Opus 4.5/4.6 sessions launched with `[1m]` model variant
- Seeds `session.contextMode` from `launchConfig.model` at session creation, boot, and init time
- Adds `contextModeFromModel()` helper to shared `context-window.ts`

## Problem

PR #43 added `resolveContextWindow()` which checks `session.model` for the `[1m]` suffix. However, assistant responses overwrite `session.model` with the bare API name (e.g. `claude-opus-4-6-20260205`), losing the suffix. If the user never runs `/model` or `/context`, `contextMode` stays undefined and the window falls through to 200K.

Opus 4.7 is unaffected (handled by `isDefault1MModel`). This only affects Opus 4.5/4.6 with explicit `[1m]` opt-in.

## Fix

Extract `contextMode` from `launchConfig.model` (which preserves the `[1m]` suffix) at three entry points:
- **boot-lifecycle.ts** — `wrapper_boot` handler
- **session-lifecycle.ts** — `meta` handler (new + resumed sessions)
- **session-store.ts** — `SessionStart` hook init model

Once `contextMode` is set, `resolveContextWindow()` returns 1M on the first check — immune to model name overwrites.

## Test plan

- [x] Spawn session with `--model claude-opus-4-6[1m]` — context bar shows 1M
- [x] Spawn session with `--model claude-opus-4-7` — shows 1M (existing)
- [x] Spawn session with `--model claude-sonnet-4-6` (no suffix) — shows 200K
- [x] Mid-session `/model` switch to 1M variant — updates to 1M

🤖 Generated with [Claude Code](https://claude.com/claude-code)