### PR TITLE
feat: opencode + ACP emit tasks_update for the task panel

### DIFF
--- a/src/acp-agent-host/index.ts
+++ b/src/acp-agent-host/index.ts
@@ -40,8 +40,11 @@ import {
   type BrokerMessage,
   type ControlDeliver,
   DEFAULT_BROKER_URL,
+  type TasksUpdate,
+  type TranscriptEntry,
   type TranscriptUserEntry,
 } from '../shared/protocol'
+import { extractTodoTasksFromEntries } from '../shared/task-extract'
 import { BUILD_VERSION } from '../shared/version'
 import {
   type AcpPermissionOption,
@@ -289,6 +292,21 @@ async function main() {
   // ─── Broker transport ─────────────────────────────────────────────────
   let transport: HostTransport
   let terminating = false
+  // Diff-dedup for tasks_update: agents replay the entire TodoWrite list on
+  // every change, so without this we'd spam the broker with identical
+  // messages every time the agent calls TodoWrite.
+  let lastTasksJson: string | null = null
+
+  function maybeEmitTasksUpdate(entries: TranscriptEntry[]) {
+    const tasks = extractTodoTasksFromEntries(entries)
+    if (!tasks) return
+    const json = JSON.stringify(tasks)
+    if (json === lastTasksJson) return
+    lastTasksJson = json
+    const msg: TasksUpdate = { type: 'tasks_update', conversationId: cfg.conversationId, tasks }
+    transport.send(msg)
+    debug(`tasks_update: ${tasks.length} tasks`)
+  }
   const shutdown = (sig: string, code = 0) => {
     if (terminating) return
     terminating = true
@@ -592,6 +610,7 @@ async function main() {
     }
     if (out.entries.length > 0) {
       transport.sendTranscriptEntries(out.entries, false)
+      maybeEmitTasksUpdate(out.entries)
     }
   }
 
@@ -793,6 +812,7 @@ async function main() {
     }
     if (finalOut.entries.length > 0) {
       transport.sendTranscriptEntries(finalOut.entries, false)
+      maybeEmitTasksUpdate(finalOut.entries)
     }
   }
 

--- a/src/claude-agent-host/task-watcher.ts
+++ b/src/claude-agent-host/task-watcher.ts
@@ -13,7 +13,7 @@ import { TASK_STATUS_PATTERN } from '../shared/task-statuses'
 import type { AgentHostContext } from './agent-host-context'
 import { debug } from './debug'
 import { listProjectTasks } from './project-tasks'
-import { normalizeTodoStatus } from './task-normalize'
+import { normalizeTodoStatus } from '../shared/task-normalize'
 
 export function readAndSendTasks(ctx: AgentHostContext) {
   if (!ctx.wsClient?.isConnected() || !ctx.claudeSessionId) {

--- a/src/claude-agent-host/transcript-manager.ts
+++ b/src/claude-agent-host/transcript-manager.ts
@@ -17,7 +17,7 @@ import type {
 import type { AgentHostContext } from './agent-host-context'
 import { debug as _debug, DEBUG } from './debug'
 import { translateClaudeToolResult, translateClaudeToolUse } from './dialect/from-claude'
-import { normalizeTodoStatus } from './task-normalize'
+import { normalizeTodoStatus } from '../shared/task-normalize'
 import { createTranscriptWatcher } from './transcript-watcher'
 
 const debug = (msg: string) => _debug(msg)

--- a/src/opencode-agent-host/index.ts
+++ b/src/opencode-agent-host/index.ts
@@ -56,9 +56,11 @@ import {
   type AgentHostBoot,
   type BrokerMessage,
   DEFAULT_BROKER_URL,
+  type TasksUpdate,
   type TranscriptEntry,
   type TranscriptUserEntry,
 } from '../shared/protocol'
+import { extractTodoTasksFromEntries } from '../shared/task-extract'
 import { BUILD_VERSION } from '../shared/version'
 import { createParserState, flushTurn, type OpenCodeEvent, parseNdjsonChunk, translateEvent } from './ndjson-parser'
 
@@ -268,6 +270,26 @@ async function main() {
   let openCodeSessionId: string | null = null
   let activeTurn: Promise<unknown> | null = null
   let transport: HostTransport
+  // Diff-dedup for tasks_update: opencode replays the entire TodoWrite list on
+  // every change, so without this we'd spam the broker with identical messages
+  // every time TodoWrite is called.
+  let lastTasksJson: string | null = null
+
+  function maybeEmitTasksUpdate(entries: TranscriptEntry[]) {
+    const tasks = extractTodoTasksFromEntries(entries)
+    if (!tasks) return
+    const json = JSON.stringify(tasks)
+    if (json === lastTasksJson) return
+    lastTasksJson = json
+    const msg: TasksUpdate = { type: 'tasks_update', conversationId: cfg.conversationId, tasks }
+    transport.send(msg)
+    debug(`tasks_update: ${tasks.length} tasks`)
+  }
+
+  function emitEntries(entries: TranscriptEntry[]) {
+    transport.sendTranscriptEntries(entries, false)
+    maybeEmitTasksUpdate(entries)
+  }
 
   function handleInbound(msg: BrokerMessage) {
     const t = (msg as { type?: string }).type
@@ -323,7 +345,7 @@ async function main() {
         cfg,
         input,
         sessionId: openCodeSessionId,
-        onEntries: entries => transport.sendTranscriptEntries(entries, false),
+        onEntries: emitEntries,
         onSessionId,
       })
     } catch (err) {

--- a/src/shared/task-extract.test.ts
+++ b/src/shared/task-extract.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test'
+import type { TranscriptEntry } from './protocol'
+import { extractTodoTasksFromEntries } from './task-extract'
+
+function assistantWithBlock(block: Record<string, unknown>): TranscriptEntry {
+  return {
+    type: 'assistant',
+    uuid: 'u',
+    timestamp: new Date().toISOString(),
+    message: { role: 'assistant', content: [block] },
+  } as TranscriptEntry
+}
+
+describe('extractTodoTasksFromEntries', () => {
+  it('returns null when no entries', () => {
+    expect(extractTodoTasksFromEntries([])).toBeNull()
+  })
+
+  it('returns null for non-todo tool_use blocks', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'shell.exec',
+      canonicalInput: { command: 'ls' },
+    })
+    expect(extractTodoTasksFromEntries([entry])).toBeNull()
+  })
+
+  it('extracts canonical todo.write block (Claude/ACP shape with activeForm)', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: {
+        todos: [
+          { content: 'Do thing', status: 'in_progress', activeForm: 'Doing thing' },
+          { content: 'Done thing', status: 'completed' },
+        ],
+      },
+    })
+    const tasks = extractTodoTasksFromEntries([entry])
+    expect(tasks).not.toBeNull()
+    expect(tasks).toHaveLength(2)
+    expect(tasks?.[0]).toMatchObject({
+      id: 'todo-0',
+      subject: 'Do thing',
+      description: 'Doing thing',
+      status: 'in_progress',
+      kind: 'todo',
+    })
+    expect(tasks?.[1]).toMatchObject({ id: 'todo-1', subject: 'Done thing', status: 'completed' })
+  })
+
+  it('extracts opencode shape (no activeForm, has priority)', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: {
+        todos: [{ content: 'Refactor', status: 'pending', priority: 2 }],
+      },
+    })
+    const tasks = extractTodoTasksFromEntries([entry])
+    expect(tasks?.[0]).toMatchObject({
+      subject: 'Refactor',
+      status: 'pending',
+      priority: 2,
+      kind: 'todo',
+    })
+    expect(tasks?.[0].description).toBeUndefined()
+  })
+
+  it('falls back to legacy block.input when canonicalInput is missing', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      input: { todos: [{ content: 'A', status: 'completed' }] },
+    })
+    const tasks = extractTodoTasksFromEntries([entry])
+    expect(tasks?.[0].subject).toBe('A')
+    expect(tasks?.[0].status).toBe('completed')
+  })
+
+  it('coerces unknown status to pending', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: { todos: [{ content: 'X', status: 'weird-state' }] },
+    })
+    const tasks = extractTodoTasksFromEntries([entry])
+    expect(tasks?.[0].status).toBe('pending')
+  })
+
+  it('returns empty array when todos array is empty (still emits tasks_update to clear list)', () => {
+    const entry = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: { todos: [] },
+    })
+    const tasks = extractTodoTasksFromEntries([entry])
+    expect(tasks).toEqual([])
+  })
+
+  it('uses the most recent todo.write block if multiple in one batch', () => {
+    const e1 = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: { todos: [{ content: 'first', status: 'pending' }] },
+    })
+    const e2 = assistantWithBlock({
+      type: 'tool_use',
+      kind: 'todo.write',
+      canonicalInput: { todos: [{ content: 'second', status: 'in_progress' }] },
+    })
+    const tasks = extractTodoTasksFromEntries([e1, e2])
+    expect(tasks).toHaveLength(1)
+    expect(tasks?.[0].subject).toBe('second')
+  })
+})

--- a/src/shared/task-extract.ts
+++ b/src/shared/task-extract.ts
@@ -1,0 +1,53 @@
+/**
+ * Extract canonical TodoWrite blocks from transcript entries and synthesize
+ * a TaskInfo[] for the broker's `tasks_update` side-channel.
+ *
+ * Used by the opencode and ACP agent hosts: both translate their backend's
+ * TodoWrite tool into a canonical `kind === 'todo.write'` block before the
+ * entry hits the wire, so a single shared scanner works for both. The Claude
+ * agent host has its own raw-name interceptor (transcript-manager.ts) because
+ * Claude's headless stream skips the canonical translator step.
+ *
+ * Returns null when no TodoWrite block was seen (no message to send).
+ */
+
+import type { TaskInfo, TranscriptEntry } from './protocol'
+import { normalizeTodoStatus } from './task-normalize'
+
+interface RawTodo {
+  content?: unknown
+  status?: unknown
+  activeForm?: unknown
+  priority?: unknown
+}
+
+export function extractTodoTasksFromEntries(entries: TranscriptEntry[]): TaskInfo[] | null {
+  let tasks: TaskInfo[] | null = null
+  for (const entry of entries) {
+    if (entry.type !== 'assistant') continue
+    const msg = (entry as Record<string, unknown>).message as Record<string, unknown> | undefined
+    const content = msg?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue
+      if (block.type !== 'tool_use') continue
+      if (block.kind !== 'todo.write') continue
+      const input = (block.canonicalInput ?? block.input) as { todos?: unknown } | undefined
+      const todos = Array.isArray(input?.todos) ? (input.todos as RawTodo[]) : []
+      const now = Date.now()
+      tasks = todos.map((todo, i) => {
+        const info: TaskInfo = {
+          id: `todo-${i}`,
+          subject: typeof todo.content === 'string' ? todo.content : '',
+          status: normalizeTodoStatus(todo.status),
+          kind: 'todo',
+          updatedAt: now,
+        }
+        if (typeof todo.activeForm === 'string') info.description = todo.activeForm
+        if (typeof todo.priority === 'number') info.priority = todo.priority
+        return info
+      })
+    }
+  }
+  return tasks
+}

--- a/src/shared/task-normalize.ts
+++ b/src/shared/task-normalize.ts
@@ -1,6 +1,11 @@
-import type { TodoTaskStatus } from '../shared/protocol'
-import { debug } from './debug'
+import type { TodoTaskStatus } from './protocol'
 
+/**
+ * Map free-text todo status values from any agent host (CC TodoWrite, opencode
+ * NDJSON, ACP) to the strict `TodoTaskStatus` enum the broker accepts. Unknown
+ * values coerce to 'pending' so the wire boundary is the only place statuses
+ * are normalized.
+ */
 const TODO_STATUS_ALIASES: Record<string, TodoTaskStatus> = {
   pending: 'pending',
   open: 'pending',
@@ -26,6 +31,5 @@ export function normalizeTodoStatus(raw: unknown): TodoTaskStatus {
   const key = raw.trim().toLowerCase()
   const mapped = TODO_STATUS_ALIASES[key]
   if (mapped) return mapped
-  debug(`unknown todo status "${raw}", coercing to pending`)
   return 'pending'
 }


### PR DESCRIPTION
## Summary

- Both opencode and ACP agent hosts already translate TodoWrite into the canonical `kind: 'todo.write'` block, but neither emitted the side-channel `tasks_update` that powers the task panel + badge + 'Mark all done' action. Result: opencode/ACP conversations had perpetually empty task panels.
- Adds `src/shared/task-extract.ts` -- scans entries for the canonical block, synthesizes `TaskInfo[]`, handles both Claude/ACP (`{ content, status, activeForm }`) and opencode (`{ content, status, priority }`) shapes.
- Lifts `task-normalize` from `claude-agent-host` to `shared/` so all three hosts share the same status alias map. Both existing import sites updated.
- Each host owns its `lastTasksJson` JSON-diff dedup (mirrors `task-watcher.ts:62`); identical lists don't hit the wire.
- No protocol changes. No new fields on `TaskInfo`. No back-compat shim.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` -- 1080 pass, 0 fail (incl. 8 new tests in `src/shared/task-extract.test.ts`)
- [x] `bun run lint:boundary` PASS
- [ ] Manual smoke: spawn an opencode conversation, ask it to make a 3-item TODO list, confirm the task panel populates and the conversation badge shows the active count
- [ ] Manual smoke: same with an ACP-backed conversation (e.g. opencode-via-ACP)