### PR TITLE
fix(broker): migrate session_id -> conversation_id on legacy DBs

### DIFF
--- a/src/broker/analytics-store.ts
+++ b/src/broker/analytics-store.ts
@@ -259,6 +259,28 @@ function migrate(d: Database): void {
   } catch (err) {
     console.error('[analytics] project_uri migration failed:', err)
   }
+
+  // v1.0.0 hard break: session_id -> conversation_id everywhere. The other
+  // stores get the rename via migrateSessionColumns(); analytics.db has no
+  // `sessions` table so it slips past that, and the CREATE INDEX call in
+  // initAnalyticsStore would then blow up on the missing column.
+  try {
+    const turnCols = d.query("PRAGMA table_info('turns')").all() as Array<{ name: string }>
+    const hasSession = turnCols.some(c => c.name === 'session_id')
+    const hasConv = turnCols.some(c => c.name === 'conversation_id')
+    if (hasSession && !hasConv) {
+      d.run('DROP INDEX IF EXISTS idx_analytics_session')
+      d.run('ALTER TABLE turns RENAME COLUMN session_id TO conversation_id')
+      console.log('[analytics] Migrated turns: renamed session_id -> conversation_id')
+    }
+    const toolCols = d.query("PRAGMA table_info('tool_uses')").all() as Array<{ name: string }>
+    if (toolCols.some(c => c.name === 'session_id') && !toolCols.some(c => c.name === 'conversation_id')) {
+      d.run('ALTER TABLE tool_uses RENAME COLUMN session_id TO conversation_id')
+      console.log('[analytics] Migrated tool_uses: renamed session_id -> conversation_id')
+    }
+  } catch (err) {
+    console.error('[analytics] session_id -> conversation_id rename failed:', err)
+  }
 }
 
 /** Backfill project_id from cwd via project-store */

--- a/src/broker/store/migrate.ts
+++ b/src/broker/store/migrate.ts
@@ -516,6 +516,19 @@ function migrateCostData(store: StoreDriver, cacheDir: string, result: Migration
       return
     }
 
+    // v1.0.0 hard break renamed session_id -> conversation_id. Legacy
+    // cost-data.db files from older brokers still have session_id, so pick
+    // whichever column is actually present and alias it.
+    const idCol = cols.some(c => c.name === 'conversation_id')
+      ? 'conversation_id'
+      : cols.some(c => c.name === 'session_id')
+        ? 'session_id'
+        : null
+    if (!idCol) {
+      result.warnings.push('cost-data.db: no conversation_id/session_id column on turns')
+      return
+    }
+
     // Prefer project_uri (post-migration DBs have already dropped the cwd column);
     // fall back to synthesizing a canonical URI from cwd for pre-migration DBs.
     // Emits `claude://default/{abs}` directly -- canonicalizeUris() will upgrade
@@ -531,7 +544,7 @@ function migrateCostData(store: StoreDriver, cacheDir: string, result: Migration
 
     const rows = legacy
       .query(
-        `SELECT timestamp, conversation_id, ${selectExpr} as project_uri,
+        `SELECT timestamp, ${idCol} as conversation_id, ${selectExpr} as project_uri,
           account, org_id, model,
           input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
           cost_usd, exact_cost


### PR DESCRIPTION
Two missing column renames from the v1.0.0 hard break:

1. `analytics.db` has its own private `migrate()` and was never told about the rename. The `CREATE INDEX ... ON turns(conversation_id)` call that follows then blows up on the missing column.

2. The `cost-data.db` legacy import in `store/migrate.ts` selects `conversation_id` directly, so any cost-data.db still on `session_id` throws mid-import.

Both fixes are idempotent (check for the legacy column first).

Tested upgrading a real ~9 MB data volume from the pre-rename schema: 462 cost turns, 3988 transcript entries, 72 conversations migrated cleanly.