### PR TITLE
feat(agent-host): rclaude --rclaude-import-history backfills local CC history to broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,13 @@ OPTIONS:
   --channels               Enable MCP channel (already default, for explicitness)
   --rclaude-version        Show build version
   --rclaude-check-update   Check if a newer version is available on GitHub
+  --rclaude-import-history --sentinel <alias> [--since <YYYY-MM-DD>] [--dry-run] [--include-agents]
+                           Upload this machine's local Claude history
+                           (~/.claude/projects) to the broker so it's searchable
+                           across machines. Idempotent (safe to re-run). <alias>
+                           must be a registered sentinel alias; sub-agent
+                           transcripts and sessions already live on the broker
+                           are skipped by default
   --rclaude-help           Show rclaude help
 
 All other arguments pass through to claude CLI.

--- a/docs/data-stores.md
+++ b/docs/data-stores.md
@@ -72,10 +72,12 @@ the turn is classified and pushed to a batch queue. Flushed every 5s or 50 recor
 
 All endpoints accept `?project=` (slug or integer ID) for per-project filtering.
 
-**Mass import:** `bun scripts/import-analytics.ts` parses historical JSONL
-transcripts from `~/.claude/projects/`. Idempotent (skips already-imported sessions).
+**Mass import:** the old `scripts/import-analytics.ts` was deleted as dead code.
+Historical-transcript backfill (FTS/transcripts, not analytics) now lives in the
+agent host: `rclaude --rclaude-import-history --sentinel <alias>` -- see the
+README CLI reference. Analytics turns are NOT retro-filled.
 
-Files: `analytics-store.ts`, `scripts/import-analytics.ts`
+Files: `analytics-store.ts`
 
 ## Cost Reporting (SQLite)
 

--- a/src/claude-agent-host/cli-args.ts
+++ b/src/claude-agent-host/cli-args.ts
@@ -3,7 +3,6 @@
  */
 
 import { readFileSync, realpathSync, unlinkSync } from 'node:fs'
-import { hostname } from 'node:os'
 import { basename, join } from 'node:path'
 import { claudeConfigDir } from '../shared/claude-config-dir'
 import { DEFAULT_BROKER_URL } from '../shared/protocol'
@@ -162,9 +161,13 @@ OPTIONS:
   --channels             Enable MCP channel (already default, for explicitness)
   --rclaude-version      Show rclaude build version
   --rclaude-check-update Check if a newer version is available on GitHub
-  --rclaude-import-history [--sentinel <name>] [--since <YYYY-MM-DD>] [--dry-run]
+  --rclaude-import-history --sentinel <alias> [--since <YYYY-MM-DD>] [--dry-run] [--include-agents]
                          Upload this machine's local Claude history (~/.claude/projects)
                          to the broker so it's searchable across machines. Idempotent.
+                         <alias> must be this machine's registered sentinel alias
+                         (validated against the broker registry). Sub-agent
+                         (agent-*.jsonl) transcripts and sessions already live on
+                         the broker are skipped by default.
   --rclaude-help         Show this help message
 
 ENVIRONMENT:
@@ -268,19 +271,34 @@ export async function parseCliArgs(args: string[]): Promise<CliConfig> {
         const idx = args.indexOf(name)
         return idx >= 0 ? args[idx + 1] : undefined
       }
-      const sentinel =
-        flagValue('--sentinel') ?? process.env.CLAUDWERK_SENTINEL_NAME ?? hostname().split('.')[0].toLowerCase()
+      // No hostname fallback: the alias becomes the project-URI authority and
+      // is validated against the broker's sentinel registry -- a guessed name
+      // would either fail validation or mint a phantom machine.
+      const sentinel = flagValue('--sentinel') ?? process.env.CLAUDWERK_SENTINEL_NAME
+      if (!sentinel) {
+        console.error(
+          'ERROR: --sentinel <alias> is required (or set CLAUDWERK_SENTINEL_NAME).\n' +
+            'Use the alias this machine is registered under on the broker (see broker-cli sentinel list).',
+        )
+        process.exit(1)
+      }
       const sinceRaw = flagValue('--since')
       const sinceMs = sinceRaw ? Date.parse(sinceRaw) : Number.NaN
       const { runImportHistory } = await import('./import-history')
-      const uploaded = await runImportHistory({
-        brokerUrl: flagValue('--broker') ?? brokerUrl,
-        brokerSecret: flagValue('--rclaude-secret') ?? brokerSecret,
-        sentinel,
-        dryRun: args.includes('--dry-run'),
-        since: Number.isNaN(sinceMs) ? undefined : sinceMs,
-      })
-      process.exit(uploaded >= 0 ? 0 : 1)
+      try {
+        await runImportHistory({
+          brokerUrl: flagValue('--broker') ?? brokerUrl,
+          brokerSecret: flagValue('--rclaude-secret') ?? brokerSecret,
+          sentinel,
+          dryRun: args.includes('--dry-run'),
+          includeAgents: args.includes('--include-agents'),
+          since: Number.isNaN(sinceMs) ? undefined : sinceMs,
+        })
+      } catch (err) {
+        console.error(`ERROR: ${err instanceof Error ? err.message : err}`)
+        process.exit(1)
+      }
+      process.exit(0)
     } else if (arg === '--broker') {
       brokerUrl = args[++i] || DEFAULT_BROKER_URL
     } else if (arg === '--rclaude-secret') {

--- a/src/claude-agent-host/cli-args.ts
+++ b/src/claude-agent-host/cli-args.ts
@@ -3,6 +3,7 @@
  */
 
 import { readFileSync, realpathSync, unlinkSync } from 'node:fs'
+import { hostname } from 'node:os'
 import { basename, join } from 'node:path'
 import { claudeConfigDir } from '../shared/claude-config-dir'
 import { DEFAULT_BROKER_URL } from '../shared/protocol'
@@ -161,6 +162,9 @@ OPTIONS:
   --channels             Enable MCP channel (already default, for explicitness)
   --rclaude-version      Show rclaude build version
   --rclaude-check-update Check if a newer version is available on GitHub
+  --rclaude-import-history [--sentinel <name>] [--since <YYYY-MM-DD>] [--dry-run]
+                         Upload this machine's local Claude history (~/.claude/projects)
+                         to the broker so it's searchable across machines. Idempotent.
   --rclaude-help         Show this help message
 
 ENVIRONMENT:
@@ -256,6 +260,27 @@ export async function parseCliArgs(args: string[]): Promise<CliConfig> {
       const result = await checkForUpdate()
       console.log(formatUpdateResult(result, detectClaudeVersion()))
       process.exit(0)
+    } else if (arg === '--rclaude-import-history') {
+      // Terminal action: backfill this machine's local Claude history to the
+      // broker, then exit. Sub-flags are scanned from the whole argv so order
+      // relative to --broker/--rclaude-secret doesn't matter.
+      const flagValue = (name: string): string | undefined => {
+        const idx = args.indexOf(name)
+        return idx >= 0 ? args[idx + 1] : undefined
+      }
+      const sentinel =
+        flagValue('--sentinel') ?? process.env.CLAUDWERK_SENTINEL_NAME ?? hostname().split('.')[0].toLowerCase()
+      const sinceRaw = flagValue('--since')
+      const sinceMs = sinceRaw ? Date.parse(sinceRaw) : Number.NaN
+      const { runImportHistory } = await import('./import-history')
+      const uploaded = await runImportHistory({
+        brokerUrl: flagValue('--broker') ?? brokerUrl,
+        brokerSecret: flagValue('--rclaude-secret') ?? brokerSecret,
+        sentinel,
+        dryRun: args.includes('--dry-run'),
+        since: Number.isNaN(sinceMs) ? undefined : sinceMs,
+      })
+      process.exit(uploaded >= 0 ? 0 : 1)
     } else if (arg === '--broker') {
       brokerUrl = args[++i] || DEFAULT_BROKER_URL
     } else if (arg === '--rclaude-secret') {

--- a/src/claude-agent-host/import-history.test.ts
+++ b/src/claude-agent-host/import-history.test.ts
@@ -2,7 +2,17 @@ import { describe, expect, it } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { deriveConversationId, ensureStableUuids, parseJsonlEntries, parseSession, recoverCwd } from './import-history'
+import type { TranscriptEntry } from '../shared/protocol'
+import { isAgentTranscriptFile } from '../shared/transcript-path'
+import {
+  deriveConversationId,
+  ensureStableUuids,
+  enumerateCandidates,
+  parseJsonlEntries,
+  parseSession,
+  planBatches,
+  recoverCwd,
+} from './import-history'
 
 describe('deriveConversationId', () => {
   it('is deterministic and namespaced under import-', () => {
@@ -58,6 +68,53 @@ describe('ensureStableUuids', () => {
   it('gives different uuids to distinct uuid-less entries', () => {
     const out = ensureStableUuids(cid, [{ type: 'a' }, { type: 'b' }] as never)
     expect(out[0].uuid).not.toBe(out[1].uuid)
+  })
+})
+
+describe('planBatches', () => {
+  const mk = (n: number): TranscriptEntry[] =>
+    Array.from({ length: n }, (_, i) => ({ type: 'user', uuid: `u${i}` }) as unknown as TranscriptEntry)
+
+  it('marks ONLY the first batch isInitial (the cache-idempotency invariant)', () => {
+    // The broker SQLite store dedupes by uuid, but the in-memory hot cache
+    // push-appends isInitial:false batches -- a re-import without a leading
+    // isInitial:true batch DOUBLES the live cache. This is the regression
+    // guard for the bug found on the first production run.
+    const batches = planBatches(mk(450))
+    expect(batches.length).toBe(3)
+    expect(batches.map(b => b.isInitial)).toEqual([true, false, false])
+    expect(batches.map(b => b.entries.length)).toEqual([200, 200, 50])
+  })
+
+  it('single short batch is isInitial', () => {
+    const batches = planBatches(mk(3))
+    expect(batches.length).toBe(1)
+    expect(batches[0].isInitial).toBe(true)
+  })
+
+  it('empty entries -> no batches', () => {
+    expect(planBatches([])).toEqual([])
+  })
+})
+
+describe('isAgentTranscriptFile', () => {
+  it('detects sub-agent sidechain transcripts by filename', () => {
+    expect(isAgentTranscriptFile('agent-a34c76776f9536490.jsonl')).toBe(true)
+    expect(isAgentTranscriptFile('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl')).toBe(false)
+    expect(isAgentTranscriptFile('agent-notes.txt')).toBe(false)
+  })
+})
+
+describe('enumerateCandidates', () => {
+  it('skips agent-*.jsonl by default and includes them with includeAgents', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'import-enum-test-'))
+    writeFileSync(join(dir, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'), '{}')
+    writeFileSync(join(dir, 'agent-a0000000000000000.jsonl'), '{}')
+    const without = await enumerateCandidates(dir, false)
+    const withAgents = await enumerateCandidates(dir, true)
+    expect(without.map(c => c.sessionUuid)).toEqual(['aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'])
+    expect(withAgents.length).toBe(2)
+    rmSync(dir, { recursive: true, force: true })
   })
 })
 

--- a/src/claude-agent-host/import-history.test.ts
+++ b/src/claude-agent-host/import-history.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { deriveConversationId, ensureStableUuids, parseJsonlEntries, parseSession, recoverCwd } from './import-history'
+
+describe('deriveConversationId', () => {
+  it('is deterministic and namespaced under import-', () => {
+    const a = deriveConversationId('ultrathink', '/Users/z/code/x', 'sess-1')
+    const b = deriveConversationId('ultrathink', '/Users/z/code/x', 'sess-1')
+    expect(a).toBe(b)
+    expect(a.startsWith('import-')).toBe(true)
+  })
+
+  it('differs by session, cwd, and sentinel', () => {
+    const base = deriveConversationId('ultrathink', '/Users/z/code/x', 'sess-1')
+    expect(deriveConversationId('ultrathink', '/Users/z/code/x', 'sess-2')).not.toBe(base)
+    expect(deriveConversationId('ultrathink', '/Users/z/code/y', 'sess-1')).not.toBe(base)
+    expect(deriveConversationId('m1', '/Users/z/code/x', 'sess-1')).not.toBe(base)
+  })
+})
+
+describe('recoverCwd', () => {
+  it('returns the first entry cwd, ignoring control lines without one', () => {
+    const entries = [
+      { type: 'custom-title' },
+      { type: 'agent-name' },
+      { type: 'user', cwd: '/Users/z/code/x' },
+      { type: 'assistant', cwd: '/Users/z/other' },
+    ] as never
+    expect(recoverCwd(entries)).toBe('/Users/z/code/x')
+  })
+
+  it('returns undefined when no entry carries a cwd', () => {
+    expect(recoverCwd([{ type: 'custom-title' }, { type: 'agent-name' }] as never)).toBeUndefined()
+  })
+})
+
+describe('ensureStableUuids', () => {
+  const cid = 'import-abc'
+
+  it('leaves entries that already have a uuid untouched', () => {
+    const entries = [{ type: 'user', uuid: 'real-uuid', cwd: '/x' }] as never
+    const out = ensureStableUuids(cid, entries)
+    expect(out[0].uuid).toBe('real-uuid')
+  })
+
+  it('synthesizes a deterministic imp- uuid for uuid-less entries (idempotent)', () => {
+    const entries = [{ type: 'custom-title', title: 'hi' }] as never
+    const first = ensureStableUuids(cid, entries)
+    const second = ensureStableUuids(cid, entries)
+    expect(first[0].uuid).toBe(second[0].uuid)
+    expect(String(first[0].uuid).startsWith('imp-')).toBe(true)
+    // preserves the original payload
+    expect((first[0] as { title?: string }).title).toBe('hi')
+  })
+
+  it('gives different uuids to distinct uuid-less entries', () => {
+    const out = ensureStableUuids(cid, [{ type: 'a' }, { type: 'b' }] as never)
+    expect(out[0].uuid).not.toBe(out[1].uuid)
+  })
+})
+
+describe('parseJsonlEntries', () => {
+  it('skips blank and malformed lines', () => {
+    const text = ['{"type":"user","uuid":"1"}', '', '   ', 'not json', '{"type":"assistant","uuid":"2"}'].join('\n')
+    const out = parseJsonlEntries(text)
+    expect(out.length).toBe(2)
+    expect(out.map(e => (e as { uuid: string }).uuid)).toEqual(['1', '2'])
+  })
+})
+
+describe('parseSession', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'import-history-test-'))
+
+  it('maps a JSONL file to an upload-ready session attributed to the sentinel', () => {
+    const file = join(dir, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl')
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({ type: 'custom-title', title: 'My Session' }),
+        JSON.stringify({
+          type: 'user',
+          uuid: 'u1',
+          cwd: '/Users/z/code/claudwerk',
+          timestamp: '2026-04-28T09:21:32.156Z',
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          uuid: 'a1',
+          cwd: '/Users/z/code/claudwerk',
+          timestamp: '2026-04-28T09:25:00.000Z',
+        }),
+      ].join('\n'),
+    )
+    const s = parseSession(file, 'ultrathink')
+    expect(s).not.toBeNull()
+    if (!s) return
+    expect(s.sessionUuid).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+    expect(s.project).toBe('claude://ultrathink/Users/z/code/claudwerk')
+    expect(s.entries.length).toBe(3)
+    // every entry carries a uuid (control line got a synthetic one)
+    expect(s.entries.every(e => typeof (e as { uuid?: unknown }).uuid === 'string')).toBe(true)
+    // time bounds derived from entry timestamps
+    expect(s.startedAt).toBe(Date.parse('2026-04-28T09:21:32.156Z'))
+    expect(s.endedAt).toBe(Date.parse('2026-04-28T09:25:00.000Z'))
+  })
+
+  it('returns null when no cwd can be recovered', () => {
+    const file = join(dir, '11111111-2222-3333-4444-555555555555.jsonl')
+    writeFileSync(file, [JSON.stringify({ type: 'custom-title' }), JSON.stringify({ type: 'agent-name' })].join('\n'))
+    expect(parseSession(file, 'ultrathink')).toBeNull()
+  })
+
+  it('returns null for an empty file', () => {
+    const file = join(dir, '99999999-2222-3333-4444-555555555555.jsonl')
+    writeFileSync(file, '')
+    expect(parseSession(file, 'ultrathink')).toBeNull()
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/src/claude-agent-host/import-history.ts
+++ b/src/claude-agent-host/import-history.ts
@@ -1,0 +1,289 @@
+/**
+ * Historical transcript import (`rclaude --rclaude-import-history`).
+ *
+ * Reads every local Claude Code transcript under
+ * `<claudeConfigDir>/projects/<slug>/*.jsonl` and uploads them to the broker
+ * over the SAME WebSocket protocol the live agent host uses (`meta` +
+ * `transcript_entries` + `end`), so the broker's FTS5 search covers this
+ * machine's history. Lives in the agent host (not broker-cli) because the broker
+ * isn't installed on every machine but `rclaude` is.
+ *
+ * Attribution: each conversation's project URI authority is the machine's
+ * sentinel name (e.g. `ultrathink`) -> `claude://ultrathink/<cwd>`, so
+ * cross-machine search distinguishes hosts. The broker takes `meta.project`
+ * verbatim, so the authority is the ONLY thing that tags a host; nothing
+ * derives it for us.
+ *
+ * Idempotent: the broker dedupes transcript entries by `(conversationId, uuid)`
+ * via INSERT OR IGNORE. Two invariants make re-runs no-ops:
+ *   1. A STABLE, machine-namespaced conversationId per local session.
+ *   2. A STABLE uuid on every entry. CC control lines (custom-title, agent-name,
+ *      permission-mode, file-history-snapshot, last-prompt) carry no uuid, and
+ *      the broker would otherwise synthesize a RANDOM one per upload -> duplicates
+ *      on every re-run. We synthesize a DETERMINISTIC uuid for those instead.
+ */
+
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+import { ccSessionIdFromJsonl } from '../daemon-agent-host/transcript-path'
+import { claudeConfigDir } from '../shared/claude-config-dir'
+import { createHostTransport } from '../shared/host-transport'
+import { cwdToProjectUri } from '../shared/project-uri'
+import {
+  AGENT_HOST_PROTOCOL_VERSION,
+  type AgentHostMessage,
+  type ConversationEnd,
+  type ConversationMeta,
+  type TranscriptEntry,
+} from '../shared/protocol'
+import { BUILD_VERSION } from '../shared/version'
+
+export interface ImportOptions {
+  brokerUrl: string
+  brokerSecret: string | undefined
+  /** Sentinel/machine name -> project URI authority (`claude://<sentinel>/...`). */
+  sentinel: string
+  dryRun: boolean
+  /** Only sessions whose newest entry is >= this epoch-ms are imported. */
+  since?: number
+  /** Defaults to `<claudeConfigDir>/projects`. */
+  projectsDir?: string
+  log?: (msg: string) => void
+}
+
+export interface ParsedSession {
+  sessionUuid: string
+  cwd: string
+  conversationId: string
+  project: string
+  startedAt: number
+  endedAt: number
+  entries: TranscriptEntry[]
+  file: string
+}
+
+/** Entries are streamed in chunks this size. 200 stays well under the transport's
+ *  oversize warning and matches the live pull default. */
+const CHUNK = 200
+/** Per-session upload hard cap so one stuck socket can't wedge the whole run. */
+const SESSION_TIMEOUT_MS = 30_000
+/** Grace period after the last frame is written before closing the socket. */
+const FLUSH_GRACE_MS = 750
+
+function sha(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+/** Stable, machine-namespaced conversation id: re-runs map to the same broker row
+ *  and imports never collide with a live session that reuses the CC session id. */
+export function deriveConversationId(sentinel: string, cwd: string, sessionUuid: string): string {
+  return `import-${sha(`${sentinel}\n${cwd}\n${sessionUuid}`).slice(0, 32)}`
+}
+
+/** Recover the real cwd from the first entry that carries one. The on-disk slug
+ *  (`/._` -> `-`) is lossy and not invertible, so we never decode it. */
+export function recoverCwd(entries: TranscriptEntry[]): string | undefined {
+  for (const e of entries) {
+    const cwd = (e as { cwd?: unknown }).cwd
+    if (typeof cwd === 'string' && cwd.length > 0) return cwd
+  }
+  return undefined
+}
+
+function entryTimeMs(e: TranscriptEntry): number | undefined {
+  const ts = (e as { timestamp?: unknown }).timestamp
+  if (typeof ts === 'string') {
+    const ms = Date.parse(ts)
+    return Number.isNaN(ms) ? undefined : ms
+  }
+  if (typeof ts === 'number') return ts
+  return undefined
+}
+
+/** Guarantee every entry has a STABLE uuid so re-uploads dedupe. Entries that
+ *  already carry one are returned untouched; uuid-less ones get a deterministic
+ *  `imp-` uuid derived from their content + position. */
+export function ensureStableUuids(conversationId: string, entries: TranscriptEntry[]): TranscriptEntry[] {
+  return entries.map((e, i) => {
+    const uuid = (e as { uuid?: unknown }).uuid
+    if (typeof uuid === 'string' && uuid.length > 0) return e
+    const synthetic = `imp-${sha(`${conversationId}\n${i}\n${JSON.stringify(e)}`).slice(0, 32)}`
+    return { ...(e as Record<string, unknown>), uuid: synthetic } as unknown as TranscriptEntry
+  })
+}
+
+export function parseJsonlEntries(text: string): TranscriptEntry[] {
+  const out: TranscriptEntry[] = []
+  for (const line of text.split('\n')) {
+    const t = line.trim()
+    if (!t) continue
+    try {
+      out.push(JSON.parse(t) as TranscriptEntry)
+    } catch {
+      // Skip malformed lines -- a partial/truncated tail shouldn't sink the file.
+    }
+  }
+  return out
+}
+
+/** Parse one session JSONL into an upload-ready ParsedSession, or null when it
+ *  has no recoverable cwd / no entries (can't attribute it to a project). */
+export function parseSession(file: string, sentinel: string): ParsedSession | null {
+  const sessionUuid = ccSessionIdFromJsonl(basename(file))
+  if (!sessionUuid) return null
+  const raw = parseJsonlEntries(readFileSync(file, 'utf-8'))
+  if (raw.length === 0) return null
+  const cwd = recoverCwd(raw)
+  if (!cwd) return null
+  const conversationId = deriveConversationId(sentinel, cwd, sessionUuid)
+  const entries = ensureStableUuids(conversationId, raw)
+  const times = raw.map(entryTimeMs).filter((n): n is number => n !== undefined)
+  const startedAt = times.length ? Math.min(...times) : Date.now()
+  const endedAt = times.length ? Math.max(...times) : startedAt
+  return {
+    sessionUuid,
+    cwd,
+    conversationId,
+    project: cwdToProjectUri(cwd, 'claude', sentinel),
+    startedAt,
+    endedAt,
+    entries,
+    file,
+  }
+}
+
+export async function enumerateSessions(
+  projectsDir: string,
+  sentinel: string,
+  since?: number,
+): Promise<ParsedSession[]> {
+  const glob = new Bun.Glob('**/*.jsonl')
+  const sessions: ParsedSession[] = []
+  for await (const file of glob.scan({ cwd: projectsDir, absolute: true })) {
+    const s = parseSession(file, sentinel)
+    if (!s) continue
+    if (since !== undefined && s.endedAt < since) continue
+    sessions.push(s)
+  }
+  // Oldest first -- deterministic, and the broker sees history in time order.
+  sessions.sort((a, b) => a.startedAt - b.startedAt)
+  return sessions
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+/** Upload one session over a dedicated short-lived transport: connect -> `meta`
+ *  (sent by buildInitialMessage on open) -> chunked `transcript_entries` -> `end`
+ *  -> brief flush grace -> close. */
+function uploadSession(s: ParsedSession, opts: ImportOptions): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const meta: ConversationMeta = {
+      type: 'meta',
+      protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+      ccSessionId: s.sessionUuid,
+      conversationId: s.conversationId,
+      project: s.project,
+      startedAt: s.startedAt,
+      agentHostType: 'claude',
+      version: `rclaude-import/${BUILD_VERSION.gitHashShort}`,
+      buildTime: BUILD_VERSION.buildTime,
+    }
+
+    let settled = false
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
+    const hardTimer = setTimeout(() => done(new Error(`timeout after ${SESSION_TIMEOUT_MS}ms`)), SESSION_TIMEOUT_MS)
+    function done(err?: Error): void {
+      if (settled) return
+      settled = true
+      clearTimeout(hardTimer)
+      if (graceTimer) clearTimeout(graceTimer)
+      try {
+        transport.close()
+      } catch {
+        /* already closed */
+      }
+      err ? reject(err) : resolve()
+    }
+
+    const transport = createHostTransport({
+      brokerUrl: opts.brokerUrl,
+      brokerSecret: opts.brokerSecret,
+      conversationId: s.conversationId,
+      buildInitialMessage: () => meta as AgentHostMessage,
+      // A batch tool must never inherit the live host's exit-on-upgrade behaviour.
+      onProtocolUpgradeRequired: 'throw',
+      onError: e => done(e instanceof Error ? e : new Error(String(e))),
+      onConnected: () => {
+        // `meta` was already sent by buildInitialMessage on open. Stream entries
+        // with the FIRST chunk as isInitial=true. This is the crux of cache
+        // idempotency: the broker's SQLite store dedupes by (conversationId,
+        // uuid), but its in-memory hot cache does NOT -- an isInitial=false batch
+        // is push-appended (add-transcript-entries.ts `appendToCache`), so a
+        // re-import would DOUBLE the live cache (store stays correct). isInitial
+        // on the first chunk makes the cache REPLACE rather than append, so a
+        // re-run re-syncs to exactly the source set on both layers. Matches how
+        // the live transcript watcher seeds a full-file read.
+        const parts = chunk(s.entries, CHUNK)
+        for (let p = 0; p < parts.length; p++) {
+          transport.sendTranscriptEntries(parts[p], p === 0)
+        }
+        const end: ConversationEnd = {
+          type: 'end',
+          conversationId: s.conversationId,
+          ccSessionId: s.sessionUuid,
+          reason: 'import-complete',
+          endedAt: s.endedAt,
+        }
+        transport.send(end as AgentHostMessage)
+        // No per-batch ack exists in the protocol; sends are synchronous while
+        // connected, so a short grace lets the socket drain before we close.
+        transport.flush()
+        graceTimer = setTimeout(() => done(), FLUSH_GRACE_MS)
+      },
+    })
+  })
+}
+
+/** Orchestrate the import. Returns the number of sessions successfully uploaded
+ *  (or the count discovered, for a dry run). */
+export async function runImportHistory(opts: ImportOptions): Promise<number> {
+  const log = opts.log ?? ((m: string) => process.stderr.write(`${m}\n`))
+  const projectsDir = opts.projectsDir ?? `${claudeConfigDir()}/projects`
+
+  log(`[import] scanning ${projectsDir} ...`)
+  const sessions = await enumerateSessions(projectsDir, opts.sentinel, opts.since)
+  const totalEntries = sessions.reduce((n, s) => n + s.entries.length, 0)
+  log(`[import] found ${sessions.length} session(s), ${totalEntries} entries -> claude://${opts.sentinel}/...`)
+
+  if (opts.dryRun) {
+    for (const s of sessions) {
+      log(`  [dry] ${s.sessionUuid}  ${String(s.entries.length).padStart(5)} entries  ${s.project}`)
+    }
+    log('[import] dry-run: nothing uploaded.')
+    return sessions.length
+  }
+
+  if (!opts.brokerSecret) {
+    throw new Error('no broker secret -- set RCLAUDE_SECRET (or pass --rclaude-secret). Refusing to connect.')
+  }
+
+  let ok = 0
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i]
+    const tag = `[${i + 1}/${sessions.length}]`
+    try {
+      await uploadSession(s, opts)
+      ok++
+      log(`  ${tag} ${s.sessionUuid}  ${s.entries.length} entries  OK`)
+    } catch (e) {
+      log(`  ${tag} ${s.sessionUuid}  FAILED: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+  log(`[import] done: ${ok}/${sessions.length} session(s) uploaded to ${opts.brokerUrl}`)
+  return ok
+}

--- a/src/claude-agent-host/import-history.ts
+++ b/src/claude-agent-host/import-history.ts
@@ -9,10 +9,20 @@
  * isn't installed on every machine but `rclaude` is.
  *
  * Attribution: each conversation's project URI authority is the machine's
- * sentinel name (e.g. `ultrathink`) -> `claude://ultrathink/<cwd>`, so
- * cross-machine search distinguishes hosts. The broker takes `meta.project`
- * verbatim, so the authority is the ONLY thing that tags a host; nothing
- * derives it for us.
+ * sentinel alias -> `claude://<alias>/<cwd>`, matching how the broker rewrites
+ * live conversations to their hosting sentinel's alias (`resolveProjectUri`).
+ * Import connections aren't sentinel-bound, so the alias arrives via
+ * `--sentinel` -- and is therefore VALIDATED against the broker's sentinel
+ * registry before anything uploads: a typo'd alias would otherwise mint a
+ * phantom machine.
+ *
+ * Skipped by default:
+ *  - Sub-agent (Task-tool sidechain) transcripts (`agent-*.jsonl`) -- the
+ *    broker's data model nests those under the parent's agent scope; imported
+ *    standalone they'd pollute the conversation list. `--include-agents` opts in.
+ *  - Sessions already live on the broker (a non-import conversation whose id
+ *    equals the local ccSessionId -- the rclaude convention) -- importing those
+ *    would index the same content twice.
  *
  * Idempotent: the broker dedupes transcript entries by `(conversationId, uuid)`
  * via INSERT OR IGNORE. Two invariants make re-runs no-ops:
@@ -21,12 +31,20 @@
  *      permission-mode, file-history-snapshot, last-prompt) carry no uuid, and
  *      the broker would otherwise synthesize a RANDOM one per upload -> duplicates
  *      on every re-run. We synthesize a DETERMINISTIC uuid for those instead.
+ *   3. The FIRST transcript_entries batch is `isInitial: true`: the SQLite store
+ *      dedupes by uuid, but the broker's in-memory hot cache push-appends
+ *      `isInitial: false` batches -- a re-import would double the live cache.
+ *      isInitial on the first batch makes the cache REPLACE instead, so re-runs
+ *      re-sync both layers to exactly the source set.
+ *
+ * Memory: sessions are parsed ONE AT A TIME inside the upload loop (not
+ * pre-loaded), so a machine with years of history doesn't hold every entry
+ * in RAM at once.
  */
 
 import { createHash } from 'node:crypto'
-import { readFileSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { basename } from 'node:path'
-import { ccSessionIdFromJsonl } from '../daemon-agent-host/transcript-path'
 import { claudeConfigDir } from '../shared/claude-config-dir'
 import { createHostTransport } from '../shared/host-transport'
 import { cwdToProjectUri } from '../shared/project-uri'
@@ -37,16 +55,21 @@ import {
   type ConversationMeta,
   type TranscriptEntry,
 } from '../shared/protocol'
+import { ccSessionIdFromJsonl, isAgentTranscriptFile } from '../shared/transcript-path'
 import { BUILD_VERSION } from '../shared/version'
+import { wsToHttpUrl } from '../shared/ws-url'
 
 export interface ImportOptions {
   brokerUrl: string
   brokerSecret: string | undefined
-  /** Sentinel/machine name -> project URI authority (`claude://<sentinel>/...`). */
+  /** Sentinel alias -> project URI authority (`claude://<alias>/...`).
+   *  Validated against the broker's sentinel registry before upload. */
   sentinel: string
   dryRun: boolean
   /** Only sessions whose newest entry is >= this epoch-ms are imported. */
   since?: number
+  /** Import sub-agent (`agent-*.jsonl`) transcripts too. Default: skip. */
+  includeAgents?: boolean
   /** Defaults to `<claudeConfigDir>/projects`. */
   projectsDir?: string
   log?: (msg: string) => void
@@ -63,12 +86,15 @@ export interface ParsedSession {
   file: string
 }
 
-/** Entries are streamed in chunks this size. 200 stays well under the transport's
+/** Entries are streamed in batches this size. 200 stays well under the transport's
  *  oversize warning and matches the live pull default. */
 const CHUNK = 200
 /** Per-session upload hard cap so one stuck socket can't wedge the whole run. */
 const SESSION_TIMEOUT_MS = 30_000
-/** Grace period after the last frame is written before closing the socket. */
+/** Grace period after the last frame is written before closing the socket.
+ *  There is no per-batch ack in the protocol; sends are synchronous while
+ *  connected, so this only covers socket-level flush. Scale note: this is a
+ *  per-session cost -- 1000 sessions pay ~12 min of pure grace. */
 const FLUSH_GRACE_MS = 750
 
 function sha(s: string): string {
@@ -113,6 +139,16 @@ export function ensureStableUuids(conversationId: string, entries: TranscriptEnt
   })
 }
 
+/** Split entries into wire batches. The FIRST batch is `isInitial: true` --
+ *  see the idempotency invariant (3) in the module doc. */
+export function planBatches(entries: TranscriptEntry[]): Array<{ entries: TranscriptEntry[]; isInitial: boolean }> {
+  const out: Array<{ entries: TranscriptEntry[]; isInitial: boolean }> = []
+  for (let i = 0; i < entries.length; i += CHUNK) {
+    out.push({ entries: entries.slice(i, i + CHUNK), isInitial: i === 0 })
+  }
+  return out
+}
+
 export function parseJsonlEntries(text: string): TranscriptEntry[] {
   const out: TranscriptEntry[] = []
   for (const line of text.split('\n')) {
@@ -153,32 +189,78 @@ export function parseSession(file: string, sentinel: string): ParsedSession | nu
   }
 }
 
-export async function enumerateSessions(
-  projectsDir: string,
-  sentinel: string,
-  since?: number,
-): Promise<ParsedSession[]> {
-  const glob = new Bun.Glob('**/*.jsonl')
-  const sessions: ParsedSession[] = []
-  for await (const file of glob.scan({ cwd: projectsDir, absolute: true })) {
-    const s = parseSession(file, sentinel)
-    if (!s) continue
-    if (since !== undefined && s.endedAt < since) continue
-    sessions.push(s)
-  }
-  // Oldest first -- deterministic, and the broker sees history in time order.
-  sessions.sort((a, b) => a.startedAt - b.startedAt)
-  return sessions
+interface CandidateFile {
+  file: string
+  sessionUuid: string
+  mtimeMs: number
 }
 
-function chunk<T>(arr: T[], size: number): T[][] {
-  const out: T[][] = []
-  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+/** Enumerate candidate JSONL files cheaply (no parsing): path + mtime only.
+ *  Agent transcripts are filtered here unless includeAgents. */
+export async function enumerateCandidates(projectsDir: string, includeAgents: boolean): Promise<CandidateFile[]> {
+  const glob = new Bun.Glob('**/*.jsonl')
+  const out: CandidateFile[] = []
+  for await (const file of glob.scan({ cwd: projectsDir, absolute: true })) {
+    const name = basename(file)
+    if (!includeAgents && isAgentTranscriptFile(name)) continue
+    const sessionUuid = ccSessionIdFromJsonl(name)
+    if (!sessionUuid) continue
+    let mtimeMs = 0
+    try {
+      mtimeMs = statSync(file).mtimeMs
+    } catch {
+      continue // vanished between scan and stat
+    }
+    out.push({ file, sessionUuid, mtimeMs })
+  }
+  // Oldest first -- deterministic, and the broker sees history in time order.
+  out.sort((a, b) => a.mtimeMs - b.mtimeMs)
   return out
 }
 
+// ─── broker HTTP preflight ──────────────────────────────────────────────────
+
+async function brokerGet(httpBase: string, path: string, secret: string): Promise<unknown | null> {
+  try {
+    const resp = await fetch(`${httpBase}${path}`, {
+      headers: { Authorization: `Bearer ${secret}` },
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!resp.ok) return null
+    return await resp.json()
+  } catch {
+    return null
+  }
+}
+
+/** Registered sentinel aliases, or null when the registry is unreachable. */
+export async function fetchRegistryAliases(httpBase: string, secret: string): Promise<string[] | null> {
+  const data = await brokerGet(httpBase, '/api/sentinels', secret)
+  if (!data) return null
+  const arr = Array.isArray(data) ? data : ((data as { sentinels?: unknown[] }).sentinels ?? [])
+  return (arr as Array<{ alias?: unknown }>).map(s => s.alias).filter((a): a is string => typeof a === 'string')
+}
+
+/** Ids of NON-import conversations on the broker. For rclaude sessions the
+ *  conversation id IS the ccSessionId, so a local session whose uuid appears
+ *  here is already on the broker live -- importing it would index the same
+ *  content twice. (Sessions promoted under a different conversationId aren't
+ *  detectable from the overview -- it doesn't expose ccSessionId -- so this
+ *  is best-effort; see PR notes.) Returns null when unreachable. */
+export async function fetchLiveConversationIds(httpBase: string, secret: string): Promise<Set<string> | null> {
+  const data = await brokerGet(httpBase, '/conversations', secret)
+  if (!data || !Array.isArray(data)) return null
+  const ids = new Set<string>()
+  for (const c of data as Array<{ id?: unknown }>) {
+    if (typeof c.id === 'string' && !c.id.startsWith('import-')) ids.add(c.id)
+  }
+  return ids
+}
+
+// ─── upload ─────────────────────────────────────────────────────────────────
+
 /** Upload one session over a dedicated short-lived transport: connect -> `meta`
- *  (sent by buildInitialMessage on open) -> chunked `transcript_entries` -> `end`
+ *  (sent by buildInitialMessage on open) -> batched `transcript_entries` -> `end`
  *  -> brief flush grace -> close. */
 function uploadSession(s: ParsedSession, opts: ImportOptions): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -219,29 +301,23 @@ function uploadSession(s: ParsedSession, opts: ImportOptions): Promise<void> {
       onProtocolUpgradeRequired: 'throw',
       onError: e => done(e instanceof Error ? e : new Error(String(e))),
       onConnected: () => {
-        // `meta` was already sent by buildInitialMessage on open. Stream entries
-        // with the FIRST chunk as isInitial=true. This is the crux of cache
-        // idempotency: the broker's SQLite store dedupes by (conversationId,
-        // uuid), but its in-memory hot cache does NOT -- an isInitial=false batch
-        // is push-appended (add-transcript-entries.ts `appendToCache`), so a
-        // re-import would DOUBLE the live cache (store stays correct). isInitial
-        // on the first chunk makes the cache REPLACE rather than append, so a
-        // re-run re-syncs to exactly the source set on both layers. Matches how
-        // the live transcript watcher seeds a full-file read.
-        const parts = chunk(s.entries, CHUNK)
-        for (let p = 0; p < parts.length; p++) {
-          transport.sendTranscriptEntries(parts[p], p === 0)
+        for (const batch of planBatches(s.entries)) {
+          transport.sendTranscriptEntries(batch.entries, batch.isInitial)
         }
         const end: ConversationEnd = {
           type: 'end',
           conversationId: s.conversationId,
           ccSessionId: s.sessionUuid,
-          reason: 'import-complete',
+          reason: 'history-import',
+          source: 'history-import',
+          detail: {
+            ccSessionId: s.sessionUuid,
+            note: `imported ${s.entries.length} entries from ${s.file}`,
+            hostVersion: `rclaude-import/${BUILD_VERSION.gitHashShort}`,
+          },
           endedAt: s.endedAt,
         }
         transport.send(end as AgentHostMessage)
-        // No per-batch ack exists in the protocol; sends are synchronous while
-        // connected, so a short grace lets the socket drain before we close.
         transport.flush()
         graceTimer = setTimeout(() => done(), FLUSH_GRACE_MS)
       },
@@ -249,33 +325,88 @@ function uploadSession(s: ParsedSession, opts: ImportOptions): Promise<void> {
   })
 }
 
+// ─── orchestration ──────────────────────────────────────────────────────────
+
 /** Orchestrate the import. Returns the number of sessions successfully uploaded
- *  (or the count discovered, for a dry run). */
+ *  (or the count that would upload, for a dry run). Throws on configuration
+ *  errors (unknown alias, unreachable broker on a real run, missing secret). */
 export async function runImportHistory(opts: ImportOptions): Promise<number> {
   const log = opts.log ?? ((m: string) => process.stderr.write(`${m}\n`))
   const projectsDir = opts.projectsDir ?? `${claudeConfigDir()}/projects`
-
-  log(`[import] scanning ${projectsDir} ...`)
-  const sessions = await enumerateSessions(projectsDir, opts.sentinel, opts.since)
-  const totalEntries = sessions.reduce((n, s) => n + s.entries.length, 0)
-  log(`[import] found ${sessions.length} session(s), ${totalEntries} entries -> claude://${opts.sentinel}/...`)
-
-  if (opts.dryRun) {
-    for (const s of sessions) {
-      log(`  [dry] ${s.sessionUuid}  ${String(s.entries.length).padStart(5)} entries  ${s.project}`)
-    }
-    log('[import] dry-run: nothing uploaded.')
-    return sessions.length
-  }
+  const httpBase = wsToHttpUrl(opts.brokerUrl)
 
   if (!opts.brokerSecret) {
     throw new Error('no broker secret -- set RCLAUDE_SECRET (or pass --rclaude-secret). Refusing to connect.')
   }
 
+  // Preflight 1: the alias must exist in the broker's sentinel registry --
+  // a typo'd --sentinel would otherwise mint a phantom machine authority.
+  const aliases = await fetchRegistryAliases(httpBase, opts.brokerSecret)
+  if (aliases === null) {
+    if (opts.dryRun) {
+      log(`[import] WARN: sentinel registry unreachable at ${httpBase} -- alias '${opts.sentinel}' NOT validated`)
+    } else {
+      throw new Error(`sentinel registry unreachable at ${httpBase} -- cannot validate --sentinel. Aborting.`)
+    }
+  } else if (!aliases.includes(opts.sentinel)) {
+    throw new Error(
+      `--sentinel '${opts.sentinel}' is not a registered sentinel alias. Registered: ${aliases.join(', ') || '(none)'}`,
+    )
+  }
+
+  // Preflight 2: ids of conversations already live on the broker (skip those).
+  const liveIds = await fetchLiveConversationIds(httpBase, opts.brokerSecret)
+  if (liveIds === null && !opts.dryRun) {
+    throw new Error(`cannot list broker conversations at ${httpBase} -- live-session dedupe unavailable. Aborting.`)
+  }
+
+  log(`[import] scanning ${projectsDir} ...`)
+  const candidates = await enumerateCandidates(projectsDir, opts.includeAgents ?? false)
+  log(
+    `[import] ${candidates.length} candidate session(s)` +
+      `${opts.includeAgents ? ' (sub-agent transcripts included)' : ' (sub-agent transcripts skipped; --include-agents to import them)'}` +
+      ` -> claude://${opts.sentinel}/...`,
+  )
+
   let ok = 0
-  for (let i = 0; i < sessions.length; i++) {
-    const s = sessions[i]
-    const tag = `[${i + 1}/${sessions.length}]`
+  let skippedLive = 0
+  let skippedUnparseable = 0
+  let skippedSince = 0
+  let totalEntries = 0
+  for (let i = 0; i < candidates.length; i++) {
+    const cand = candidates[i]
+    const tag = `[${i + 1}/${candidates.length}]`
+
+    if (liveIds?.has(cand.sessionUuid)) {
+      skippedLive++
+      log(`  ${tag} ${cand.sessionUuid}  SKIP (already live on broker)`)
+      continue
+    }
+    // Cheap mtime prefilter -- a file last written before --since can't have
+    // newer entries. The precise endedAt check below still applies.
+    if (opts.since !== undefined && cand.mtimeMs < opts.since) {
+      skippedSince++
+      continue
+    }
+
+    // Parse lazily, one session at a time -- `s` goes out of scope each loop.
+    const s = parseSession(cand.file, opts.sentinel)
+    if (!s) {
+      skippedUnparseable++
+      log(`  ${tag} ${cand.sessionUuid}  SKIP (no recoverable cwd / empty)`)
+      continue
+    }
+    if (opts.since !== undefined && s.endedAt < opts.since) {
+      skippedSince++
+      continue
+    }
+
+    totalEntries += s.entries.length
+    if (opts.dryRun) {
+      ok++
+      log(`  [dry] ${s.sessionUuid}  ${String(s.entries.length).padStart(5)} entries  ${s.project}`)
+      continue
+    }
     try {
       await uploadSession(s, opts)
       ok++
@@ -284,6 +415,12 @@ export async function runImportHistory(opts: ImportOptions): Promise<number> {
       log(`  ${tag} ${s.sessionUuid}  FAILED: ${e instanceof Error ? e.message : String(e)}`)
     }
   }
-  log(`[import] done: ${ok}/${sessions.length} session(s) uploaded to ${opts.brokerUrl}`)
+
+  const skips = `skipped: ${skippedLive} live, ${skippedSince} before --since, ${skippedUnparseable} unparseable`
+  if (opts.dryRun) {
+    log(`[import] dry-run: ${ok} session(s) / ${totalEntries} entries would upload (${skips}). Nothing sent.`)
+  } else {
+    log(`[import] done: ${ok} session(s) / ${totalEntries} entries uploaded to ${opts.brokerUrl} (${skips})`)
+  }
   return ok
 }

--- a/src/daemon-agent-host/transcript-path.ts
+++ b/src/daemon-agent-host/transcript-path.ts
@@ -44,13 +44,7 @@ export function transcriptJsonlPath(cwd: string, ccSessionId: string): string {
   return join(transcriptProjectDir(cwd), `${ccSessionId}.jsonl`)
 }
 
-/**
- * The `ccSessionId` encoded in a transcript JSONL file name, or `null` if the
- * name is not a `<id>.jsonl`. The id IS the file's base name -- a daemon
- * worker's live ccSessionId is exactly the name of the JSONL it is writing.
- */
-export function ccSessionIdFromJsonl(fileName: string): string | null {
-  if (!fileName.endsWith('.jsonl')) return null
-  const id = fileName.slice(0, -'.jsonl'.length)
-  return id.length > 0 ? id : null
-}
+// ccSessionIdFromJsonl moved to src/shared/transcript-path.ts (the history
+// import needs the filename <-> id mapping too); re-exported so existing
+// daemon-side imports keep working unchanged.
+export { ccSessionIdFromJsonl } from '../shared/transcript-path'

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -2250,6 +2250,7 @@ export type TerminationSource =
   // Agent host -- intentional shutdown
   | 'mcp-exit-session' // agent self-terminated via mcp__rclaude__exit_session
   | 'headless-input' // user typed /exit /quit :q :q! into headless stdin
+  | 'history-import' // end-of-batch-upload marker (rclaude --rclaude-import-history); not a real kill
   // Agent host -- CC process events
   | 'cc-exit-normal' // CC exited code 0
   | 'cc-exit-crash' // CC exited non-zero or by signal

--- a/src/shared/transcript-path.ts
+++ b/src/shared/transcript-path.ts
@@ -1,0 +1,30 @@
+/**
+ * Host-agnostic helpers for Claude Code's on-disk transcript naming
+ * (`<configDir>/projects/<slug>/<ccSessionId>.jsonl`).
+ *
+ * Lives in `src/shared/` because more than one host needs the
+ * filename <-> ccSessionId mapping: the daemon host's session observer
+ * (live JSONL discovery) and the claude host's history import (batch
+ * backfill). The daemon-specific path *construction* (slugging, realpath,
+ * profile config dirs) stays in `src/daemon-agent-host/transcript-path.ts`.
+ */
+
+/**
+ * The `ccSessionId` encoded in a transcript JSONL file name, or `null` if the
+ * name is not a `<id>.jsonl`. The id IS the file's base name -- a CC session's
+ * ccSessionId is exactly the name of the JSONL it writes.
+ */
+export function ccSessionIdFromJsonl(fileName: string): string | null {
+  if (!fileName.endsWith('.jsonl')) return null
+  const id = fileName.slice(0, -'.jsonl'.length)
+  return id.length > 0 ? id : null
+}
+
+/**
+ * Whether a transcript file is a sub-agent (Task-tool sidechain) transcript.
+ * CC writes those as `agent-<hex>.jsonl` next to the parent session's JSONL;
+ * every entry inside carries `isSidechain: true`.
+ */
+export function isAgentTranscriptFile(fileName: string): boolean {
+  return fileName.startsWith('agent-') && fileName.endsWith('.jsonl')
+}


### PR DESCRIPTION
## What

Adds `rclaude --rclaude-import-history --sentinel <alias> [--since <YYYY-MM-DD>]
[--dry-run] [--include-agents]` — a wrapper subcommand that reads
`~/.claude/projects/**/*.jsonl` and uploads every local Claude Code session to the
broker over the existing `meta` + `transcript_entries` + `end` protocol, so FTS5
search covers history from machines that were never live on it. No broker changes
required (one additive `TerminationSource` enum value aside).

It lives in the agent host (not `broker-cli`) on purpose: the broker isn't installed
on every machine, but `rclaude` is.

## Why

Transcripts only reach the broker live, over WebSocket, while an agent host runs.
There was no path to backfill a machine's existing `~/.claude` history, so
cross-machine search missed everything recorded before a host joined the fabric.
(`scripts/import-analytics.ts` used to cover the *analytics* side but was removed as
dead code; `docs/data-stores.md` still pointed at it — fixed here.)

## Design

- **Attribution** — the broker derives live conversations' URI authority from the
  hosting sentinel (`resolveProjectUri`). Import connections aren't sentinel-bound,
  so the alias arrives via `--sentinel` and is **validated against
  `GET /api/sentinels` before anything uploads**; an unknown alias aborts with the
  registered list. No hostname guessing.
- **Skips by default** — sub-agent `agent-*.jsonl` (sidechain) transcripts, which
  belong in the parent's agent scope rather than as top-level conversations
  (`--include-agents` opts in), and sessions already live on the broker
  (non-import conversation id == local ccSessionId), so content is never indexed
  twice.
- **Idempotency** — deterministic machine-namespaced `conversationId`; stable
  per-entry uuid (deterministic synthesis for CC's uuid-less control lines, which
  the broker would otherwise randomize per upload); and the first
  `transcript_entries` batch sent `isInitial: true` — the SQLite store dedupes by
  `(conversationId, uuid)` but the in-memory hot cache push-appends
  `isInitial:false` batches, so a re-import without the leading initial batch
  doubles the live cache. Regression-tested (`planBatches`).
- **Footprint** — sessions parse lazily one-at-a-time inside the upload loop;
  `--since` prefilters by file mtime. `end` frames carry the new typed
  `source: 'history-import'` so the termination NDJSON stays auditable.
- `ccSessionIdFromJsonl` moved to `src/shared/transcript-path.ts` (the claude host
  was importing it from `daemon-agent-host`, against the agent-host-common grain);
  daemon re-exports unchanged.

## Testing

- `import-history.test.ts`: deterministic-id stability, synthetic-uuid idempotency,
  cwd recovery, JSONL parsing, agent-file filtering, and the first-batch-isInitial
  invariant.
- Verified against a live broker: 24 sessions / ~12.5k entries imported under a
  validated alias; back-to-back runs hold `rows == distinct uuids == source` per
  conversation (incl. a 3,109-entry session); alias typo and missing-flag paths
  fail correctly; termination records land typed.
- `bun test`: no new failures (2 pre-existing on main: `mirrorWorker` timeout
  flake, env-sensitive `settings-merge` baseline).

## Known limitations (follow-up candidates)

- Live-session dedupe keys on conversation id == ccSessionId (the rclaude
  convention); conversations promoted under a different id aren't detectable from
  the overview, which doesn't expose `ccSessionId`.
- One short-lived WS per session + fixed 750 ms flush grace (no per-batch ack in
  the protocol): ~1000-session machines pay ~12 min of grace. A sync-check-style
  "what do you already have" preflight would remove re-upload traffic entirely.
- Authority is validated but still client-claimed; cryptographic attribution from a
  sentinel-bound connection would need a new role + message type.
- Imported conversations are searchable but not registered in the project registry
  (`/api/projects`), so they don't appear in the dashboard project tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
