### PR TITLE
feat(web): add Shift modifier lock to terminal toolbar for Shift-Tab

### DIFF
--- a/web/src/components/terminal-toolbar.tsx
+++ b/web/src/components/terminal-toolbar.tsx
@@ -30,7 +30,14 @@ const CLAUDE_SHORTCUTS: ShortcutButton[] = [
   { label: 'M-o fast', data: '\x1bo', title: 'Toggle fast mode (Alt+O)' },
 ]
 
-type Modifier = 'ctrl' | 'alt' | 'meta'
+// Shift transforms special keys into distinct escape sequences (not a simple prefix).
+const SHIFT_MAP: Record<string, string> = {
+  '\t': '\x1b[Z', // Shift+Tab  -> back-tab (Claude Code: cycle modes)
+  '\x1b[A': '\x1b[1;2A', // Shift+Up
+  '\x1b[B': '\x1b[1;2B', // Shift+Down
+}
+
+type Modifier = 'ctrl' | 'alt' | 'meta' | 'shift'
 
 export function TerminalToolbar({ onSend }: TerminalToolbarProps) {
   const [showClaude, setShowClaude] = useState(false)
@@ -44,6 +51,11 @@ export function TerminalToolbar({ onSend }: TerminalToolbarProps) {
       } catch {
         // Clipboard permission denied or unavailable
       }
+      return
+    }
+    if (activeModifier === 'shift') {
+      onSend(SHIFT_MAP[data] ?? data)
+      setActiveModifier(null)
       return
     }
     onSend(data)
@@ -67,6 +79,9 @@ export function TerminalToolbar({ onSend }: TerminalToolbarProps) {
         break
       case 'meta':
         data = `\x1b${key}`
+        break
+      case 'shift':
+        data = key.toUpperCase()
         break
       default:
         return
@@ -102,7 +117,7 @@ export function TerminalToolbar({ onSend }: TerminalToolbarProps) {
         <div className="w-px h-5 bg-border mx-1" />
 
         {/* Modifier locks */}
-        {(['ctrl', 'alt', 'meta'] as Modifier[]).map(mod => (
+        {(['ctrl', 'alt', 'meta', 'shift'] as Modifier[]).map(mod => (
           <button
             key={mod}
             type="button"


### PR DESCRIPTION
## What
Adds a `shift` modifier lock to the terminal toolbar, alongside the existing `ctrl`/`alt`/`meta` locks.

## Why
The toolbar had no Shift, so there was no way to send **Shift-Tab** from a touch device (iOS) — the keystroke Claude Code uses to cycle permission modes (normal → auto-accept → plan).

## How
Shift-Tab is not "Shift + the Tab byte" — terminals emit it as the distinct escape sequence `\x1b[Z` (CSI Z, back-tab). So the Shift lock maps keys via a `SHIFT_MAP` rather than prefixing like `alt`/`meta`:
- `Tab → \x1b[Z`, `Up/Down → \x1b[1;2A`/`\x1b[1;2B` (shift-arrows)
- letters simply uppercase
- non-shiftable shortcuts (`^C`, `Esc`, paste) pass through unchanged and clear the lock

One file changed (`web/src/components/terminal-toolbar.tsx`); shared by both the full-screen and inline terminals. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)