### PR TITLE
build(docker): build web bundle in-container for a self-contained image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ src/shared/version.ts
 NOTES.md
 .rclaude/
 .nightshift/
+.launchfile/
+.env.local
 /store.db
 /store.db-shm
 /store.db-wal

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,12 @@ RUN bun install --frozen-lockfile && cd web && bun install --frozen-lockfile
 # `docker build .` invocations are deliberately discouraged (see docker-compose.yml).
 COPY . .
 
-# Build server binaries only (web is built locally and volume-mounted).
+# Build web + server binaries fully in-container so the image builds from any
+# clean context (git archive, a fresh clone, or a Launchfile-driven compose
+# build) without host-side prebuild steps. Production still bind-mounts a
+# locally-built web/dist over /srv/web; the baked copy is the offline fallback.
 # build:broker's dirty-tree check no-ops here because .git is not in the context.
-RUN bun run gen-version && bun run build:broker && bun run build:cli
+RUN bun run gen-version && bun run build:web && bun run build:broker && bun run build:cli
 
 # Runtime stage - minimal image
 FROM debian:bookworm-slim
@@ -39,8 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /build/bin/broker /usr/local/bin/broker
 COPY --from=builder /build/bin/broker-cli /usr/local/bin/broker-cli
 
-# Copy pre-built web assets (built locally with Vite 8, volume-mounted in production)
-COPY web/dist /srv/web
+# Copy web assets built in the builder stage (volume-mounted over in production)
+COPY --from=builder /build/web/dist /srv/web
 
 # Data directories
 RUN mkdir -p /data/cache /data/transcripts


### PR DESCRIPTION
**What:** Build the web bundle inside the Docker builder stage instead of copying a host-prebuilt `web/dist` into the runtime image.

**Why:** The runtime stage did `COPY web/dist /srv/web`, so the image only built correctly when web assets had been prebuilt on the host — and could silently bake in a *stale* bundle. This breaks `docker build` from a clean context (fresh clone, `git archive`, or a Launchfile/compose build).

**How:**
- Builder stage runs `bun run build:web` alongside the broker/cli builds.
- Runtime stage copies `web/dist` from the builder (`COPY --from=builder /build/web/dist /srv/web`).
- Production still bind-mounts a locally-built `web/dist` over `/srv/web`; the baked copy is the offline fallback.
- Also gitignores `.launchfile/` and `.env.local` (local deploy artifacts).

**Testing:** Verified with a full `docker build` from a clean context — Vite build runs in-container (5158 modules), broker + CLI compile, image builds (525MB), exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
